### PR TITLE
feat: add automatic filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 out
+usage.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grammyjs/commands",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grammyjs/commands",
-      "version": "1.0.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "grammy": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@grammyjs/commands",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "description": "grammY Commands Plugin",
   "main": "out/mod.js",
   "scripts": {
-    "prepare": "deno task backport"
+    "prepublishOnly": "deno task backport"
   },
   "keywords": [
     "grammY",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "grammY Commands Plugin",
   "main": "out/mod.js",
   "scripts": {
-    "prepublishOnly": "deno task backport"
+    "prepare": "deno task backport"
   },
   "keywords": [
     "grammY",

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,21 +1,17 @@
-import {
+import type {
   BotCommand,
   BotCommandScope,
   BotCommandScopeAllChatAdministrators,
   BotCommandScopeAllGroupChats,
   BotCommandScopeAllPrivateChats,
-  Chat,
-  ChatTypeContext,
-  Composer,
+  ChatTypeMiddleware,
   Context,
-  match,
   Middleware,
   MiddlewareObj,
-  P,
 } from "./deps.deno.ts";
+import { Composer, match, P } from "./deps.deno.ts";
 
 export type MaybeArray<T> = T | T[];
-export type ChatTypeMiddleware<C extends Context, T extends Chat["type"]> = Middleware<ChatTypeContext<C, T>>;
 type BotCommandGroupsScope = BotCommandScopeAllGroupChats | BotCommandScopeAllChatAdministrators;
 
 const isAdmin = (ctx: Context) =>

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -4,6 +4,7 @@ export {
   Api,
   Bot,
   type ChatTypeContext,
+  type ChatTypeMiddleware,
   type CommandMiddleware,
   Composer,
   Context,

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -1,12 +1,21 @@
 // TODO: Replace with official deno module, once it arrives (https://github.com/gvergnaud/ts-pattern/pull/108)
 export { match, P } from "https://deno.land/x/fuzzy_octo_guacamole@v5.0.1/mod.ts";
 export {
+  Api,
   Bot,
   type ChatTypeContext,
   type CommandMiddleware,
   Composer,
   Context,
   type Middleware,
+  type MiddlewareObj,
   type NextFunction,
 } from "https://lib.deno.dev/x/grammy@1/mod.ts";
-export type { BotCommand, BotCommandScope, Chat } from "https://lib.deno.dev/x/grammy@1/types.ts";
+export type {
+  BotCommand,
+  BotCommandScope,
+  BotCommandScopeAllChatAdministrators,
+  BotCommandScopeAllGroupChats,
+  BotCommandScopeAllPrivateChats,
+  Chat,
+} from "https://lib.deno.dev/x/grammy@1/types.ts";

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -1,12 +1,21 @@
 // TODO: Replace with official deno module, once it arrives (https://github.com/gvergnaud/ts-pattern/pull/108)
 export {
+  Api,
   Bot,
   type ChatTypeContext,
   type CommandMiddleware,
   Composer,
   Context,
   type Middleware,
+  type MiddlewareObj,
   type NextFunction,
 } from "grammy";
-export type { BotCommand, BotCommandScope, Chat } from "grammy/types";
+export type {
+  BotCommand,
+  BotCommandScope,
+  BotCommandScopeAllChatAdministrators,
+  BotCommandScopeAllGroupChats,
+  BotCommandScopeAllPrivateChats,
+  Chat,
+} from "grammy/types";
 export { match, P } from "ts-pattern";

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -3,6 +3,7 @@ export {
   Api,
   Bot,
   type ChatTypeContext,
+  type ChatTypeMiddleware,
   type CommandMiddleware,
   Composer,
   Context,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,5 @@
 import { Command } from "./command.ts";
-import { Bot, BotCommand, BotCommandScope, Context, match, Middleware } from "./deps.deno.ts";
+import { Api, BotCommand, BotCommandScope, Composer, Context } from "./deps.deno.ts";
 
 type SetMyCommandsParams = {
   scope?: BotCommandScope;
@@ -8,41 +8,55 @@ type SetMyCommandsParams = {
 };
 
 export class Commands<C extends Context> {
-  #languages: Set<string> = new Set();
-  #scopes: Map<string, Array<Command<C>>> = new Map();
-  #commands: Command<C>[] = [];
+  private _languages: Set<string> = new Set();
+  private _scopes: Map<string, Array<Command<C>>> = new Map();
+  private _commands: Command<C>[] = [];
+  private _composer: Composer<C> = new Composer();
 
   constructor(commands: Command<C>[] = []) {
-    commands.forEach((command) => this.#commands.push(command));
+    commands.forEach((command) => this._commands.push(command));
   }
 
-  #addCommandToScope(scope: BotCommandScope, command: Command<C>) {
-    const commands = this.#scopes.get(JSON.stringify(scope)) ?? [];
-    this.#scopes.set(JSON.stringify(scope), commands.concat([command]));
+  private _addCommandToScope(scope: BotCommandScope, command: Command<C>) {
+    const commands = this._scopes.get(JSON.stringify(scope)) ?? [];
+    this._scopes.set(JSON.stringify(scope), commands.concat([command]));
   }
 
-  #populate() {
-    this.#languages = new Set();
-    this.#scopes = new Map();
+  private _populateComposer() {
+    for (const command of this._commands) {
+      for (const args of command.languages.values()) {
+        this._composer.command(args.name, command.middleware());
+      }
+    }
+  }
 
-    this.#commands.forEach((command) => {
-      command.scopes.forEach((scope) => this.#addCommandToScope(scope, command));
-      Array.from(command.languages.keys()).forEach((language) => this.#languages.add(language));
+  private _populateMetadata() {
+    this._languages.clear();
+    this._scopes.clear();
+
+    this._commands.forEach((command) => {
+      for (const scope of command.scopes) {
+        this._addCommandToScope(scope, command);
+      }
+
+      for (const language of command.languages.keys()) {
+        this._languages.add(language);
+      }
     });
   }
 
-  public command(name: string, description: string, ...middleware: Array<Middleware<C>>) {
-    const command = new Command(name, description, ...middleware);
-    this.#commands.push(command);
+  public command(name: string, description: string) {
+    const command = new Command<C>(name, description);
+    this._commands.push(command);
     return command;
   }
 
   public toArgs() {
-    this.#populate();
+    this._populateMetadata();
     const params: SetMyCommandsParams[] = [];
 
-    for (const [scope, commands] of this.#scopes.entries()) {
-      for (const language of this.#languages) {
+    for (const [scope, commands] of this._scopes.entries()) {
+      for (const language of this._languages) {
         params.push({
           scope: JSON.parse(scope),
           language_code: language === "default" ? undefined : language,
@@ -55,14 +69,14 @@ export class Commands<C extends Context> {
   }
 
   public toSingleScopeArgs(scope: BotCommandScope) {
-    this.#populate();
+    this._populateMetadata();
     const params: SetMyCommandsParams[] = [];
 
-    for (const language of this.#languages) {
+    for (const language of this._languages) {
       params.push({
         scope,
-        language_code: match(language).with("default", () => undefined).otherwise((value) => value),
-        commands: this.#commands
+        language_code: language === "default" ? undefined : language,
+        commands: this._commands
           .filter((command) => command.scopes.length)
           .map((command) => command.toObject(language)),
       });
@@ -71,10 +85,8 @@ export class Commands<C extends Context> {
     return params;
   }
 
-  public setFor<C extends Context>(bot: Bot<C>) {
-    const argsArray = this.toArgs();
-    const promises = argsArray.map((args) => bot.api.raw.setMyCommands(args));
-    return Promise.all(promises);
+  public async setCommands({ api }: { api: Api }) {
+    await Promise.all(this.toArgs().map((args) => api.raw.setMyCommands(args)));
   }
 
   public toJSON() {
@@ -83,6 +95,11 @@ export class Commands<C extends Context> {
 
   public toString() {
     return JSON.stringify(this);
+  }
+
+  middleware() {
+    this._populateComposer();
+    return this._composer.middleware();
   }
 
   [Symbol.for("Deno.customInspect")]() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,6 @@
     "skipLibCheck": true,
     "outDir": "out",
     "declaration": true
-  }
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
Major redesign to better support filtering.
Proposed usage:

```typescript
import { Bot } from "./src/deps.deno.ts";
import { Commands } from "./src/plugin.ts";

const bot = new Bot("...");

const cmds = new Commands();

cmds.command("start", "Initializes bot configuration")
  .localize("pt", "start", "Inicializa as configurações do bot")
  .addToScope({ type: "all_private_chats" }, (ctx) => ctx.reply(`Hello, ${ctx.chat.first_name}!`))
  .addToScope({ type: "all_group_chats" }, (ctx) => ctx.reply(`Hello, members of ${ctx.chat.title}!`));

await cmds.setCommands(bot);

bot.use(cmds);
bot.start();
```
