### PR TITLE
Fix middleware context type

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -97,7 +97,7 @@ export class Commands<C extends Context> {
     public command(
         name: string | RegExp,
         description: string,
-        handler: MaybeArray<Middleware<C>>,
+        handler: MaybeArray<Middleware<CommandContext<C>>>,
         options?: Partial<CommandOptions>,
     ): Command<C>;
     /**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,3 +1,4 @@
+import { CommandContext } from "https://deno.land/x/grammy@v1.22.4/mod.ts";
 import { Command, MaybeArray } from "./command.ts";
 import {
     Api,
@@ -20,7 +21,7 @@ type SetMyCommandsParams = {
 
 const isMiddleware = <C extends Context>(
     obj: unknown,
-): obj is MaybeArray<Middleware<C>> => {
+): obj is MaybeArray<Middleware<CommandContext<C>>> => {
     if (!obj) return false;
     if (Array.isArray(obj)) return obj.every(isMiddleware);
     const objType = typeof obj;
@@ -114,7 +115,7 @@ export class Commands<C extends Context> {
     public command(
         name: string | RegExp,
         description: string,
-        handlerOrOptions?: MaybeArray<Middleware<C>> | Partial<CommandOptions>,
+        handlerOrOptions?: MaybeArray<Middleware<CommandContext<C>>> | Partial<CommandOptions>,
         _options?: Partial<CommandOptions>,
     ) {
         const handler = isMiddleware(handlerOrOptions)


### PR DESCRIPTION
Before the fix some native properties of the context object where missing, as it didn't share the CommandContext type.
Still type error on addToScope