### PR TITLE
Fix middleware command context type

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -52,7 +52,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
      *
      * @param name Default command name
      * @param description Default command description
-     * @param options Options object that shuold apply to this command only
+     * @param options Options object that should apply to this command only
      * @access package
      */
     constructor(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,6 +3,7 @@ import {
     Api,
     BotCommand,
     BotCommandScope,
+    CommandContext,
     Composer,
     Context,
     Middleware,
@@ -96,7 +97,7 @@ export class Commands<C extends Context> {
     public command(
         name: string | RegExp,
         description: string,
-        handler: MaybeArray<Middleware<C>>,
+        handler: MaybeArray<Middleware<CommandContext<C>>>,
         options?: Partial<CommandOptions>,
     ): Command<C>;
     /**
@@ -114,7 +115,7 @@ export class Commands<C extends Context> {
     public command(
         name: string | RegExp,
         description: string,
-        handlerOrOptions?: MaybeArray<Middleware<C>> | Partial<CommandOptions>,
+        handlerOrOptions?: MaybeArray<Middleware<CommandContext<C>>> | Partial<CommandOptions>,
         _options?: Partial<CommandOptions>,
     ) {
         const handler = isMiddleware(handlerOrOptions)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -115,7 +115,9 @@ export class Commands<C extends Context> {
     public command(
         name: string | RegExp,
         description: string,
-        handlerOrOptions?: MaybeArray<Middleware<CommandContext<C>>> | Partial<CommandOptions>,
+        handlerOrOptions?:
+            | MaybeArray<Middleware<CommandContext<C>>>
+            | Partial<CommandOptions>,
         _options?: Partial<CommandOptions>,
     ) {
         const handler = isMiddleware(handlerOrOptions)

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -3,13 +3,13 @@ export {
     Bot,
     type ChatTypeContext,
     type ChatTypeMiddleware,
+    type CommandContext,
     type CommandMiddleware,
     Composer,
     Context,
     type Middleware,
     type MiddlewareObj,
     type NextFunction,
-    type CommandContext,
 } from "https://lib.deno.dev/x/grammy@1/mod.ts";
 export type {
     BotCommand,

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -9,6 +9,7 @@ export {
     type Middleware,
     type MiddlewareObj,
     type NextFunction,
+    type CommandContext,
 } from "https://lib.deno.dev/x/grammy@1/mod.ts";
 export type {
     BotCommand,

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -3,6 +3,7 @@ export {
     Bot,
     type ChatTypeContext,
     type ChatTypeMiddleware,
+    type CommandContext,
     type CommandMiddleware,
     Composer,
     Context,


### PR DESCRIPTION
Previous to the fix, command context properties, like c.chat, were missing from the Command Context.