### PR TITLE
feat: enable mixin of commands for ctx

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -37,7 +37,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
     private _scopes: BotCommandScope[] = [];
     private _languages: Map<
         string,
-        { name: string | RegExp; description: string }
+        { name: string; description: string }
     > = new Map();
     private _composer: Composer<C> = new Composer<C>();
     private _options: CommandOptions = {
@@ -56,7 +56,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
      * @access package
      */
     constructor(
-        name: string | RegExp,
+        name: string,
         description: string,
         options: Partial<CommandOptions> = {},
     ) {
@@ -264,11 +264,11 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
      */
     public localize(
         languageCode: string,
-        name: string | RegExp,
+        name: string,
         description: string,
     ) {
         this._languages.set(languageCode, {
-            name: new RegExp(name),
+            name: name,
             description,
         });
         return this;
@@ -301,9 +301,8 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
      * @returns Object representation of this command
      */
     public toObject(languageCode = "default"): BotCommand {
-        const localizedName = this.getLocalizedName(languageCode);
         return {
-            command: localizedName instanceof RegExp ? "" : localizedName,
+            command: this.getLocalizedName(languageCode),
             description: this.getLocalizedDescription(languageCode),
         };
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -10,9 +10,10 @@ import {
 } from "./deps.deno.ts";
 import { CommandOptions } from "./types.ts";
 
-type SetMyCommandsParams = {
+export type SetMyCommandsParams = {
     /**
      * Scope
+     * @param language_code two letter abbreviation in ISO_639 standard: https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
      */
     scope?: BotCommandScope;
     language_code?: string;
@@ -113,7 +114,7 @@ export class Commands<C extends Context> {
         options?: Partial<CommandOptions>,
     ): Command<C>;
     public command(
-        name: string | RegExp,
+        name: string,
         description: string,
         handlerOrOptions?:
             | MaybeArray<Middleware<CommandContext<C>>>
@@ -171,7 +172,6 @@ export class Commands<C extends Context> {
     public toSingleScopeArgs(scope: BotCommandScope) {
         this._populateMetadata();
         const params: SetMyCommandsParams[] = [];
-
         for (const language of this._languages) {
             params.push({
                 scope,
@@ -181,7 +181,6 @@ export class Commands<C extends Context> {
                     .map((command) => command.toObject(language)),
             });
         }
-
         return params;
     }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,7 +12,7 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
      */
     setMyCommands: (
         commands: Commands<C>,
-        ...rest: Commands<C>[]
+        ...moreCommands: Commands<C>[]
     ) => Promise<void>;
     /**
      * Returns the nearest command to the user input.

--- a/src/context.ts
+++ b/src/context.ts
@@ -81,7 +81,7 @@ export function commands<C extends Context>() {
 function mergeMyCommandsParams(
     commandParams: SetMyCommandsParams[][],
 ): SetMyCommandsParams[] {
-    if (!commandParams.flat().length) { return [] }
+    if (!commandParams.flat().length) return [];
     return commandParams
         .flat()
         .sort((a, b) => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,7 +10,10 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
      * @param commands List of available commands
      * @returns Promise with the result of the operations
      */
-    setMyCommands: (commands: Commands<C>, ...rest : Commands <C>[]) => Promise<void>;
+    setMyCommands: (
+        commands: Commands<C>,
+        ...rest: Commands<C>[]
+    ) => Promise<void>;
     /**
      * Returns the nearest command to the user input.
      * If no command is found, returns `null`.
@@ -30,18 +33,24 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
  */
 export function commands<C extends Context>() {
     return (ctx: CommandsFlavor<C>, next: NextFunction) => {
-        ctx.setMyCommands = async (commands, ...moreCommands : Commands<C>[]) => {
+        ctx.setMyCommands = async (
+            commands,
+            ...moreCommands: Commands<C>[]
+        ) => {
             if (!ctx.chat) {
                 throw new Error(
                     "cannot call `ctx.setMyCommands` on an update with no `chat` property",
                 );
             }
 
-            const commandsMixin = [commands].concat(moreCommands).values()
-            for(const commands of commandsMixin){
+            const commandsMixin = [commands].concat(moreCommands).values();
+            for (const commands of commandsMixin) {
                 await Promise.all(
                     commands
-                        .toSingleScopeArgs({ type: "chat", chat_id: ctx.chat.id })
+                        .toSingleScopeArgs({
+                            type: "chat",
+                            chat_id: ctx.chat.id,
+                        })
                         .map((args) => ctx.api.raw.setMyCommands(args)),
                 );
             }

--- a/src/context.ts
+++ b/src/context.ts
@@ -43,7 +43,7 @@ export function commands<C extends Context>() {
                 );
             }
 
-            const commandsMixin = [commands].concat(moreCommands).values();
+            const commandsMixin = [commands].concat(moreCommands);
             for (const commands of commandsMixin) {
                 await Promise.all(
                     commands

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,7 +10,7 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
      * @param commands List of available commands
      * @returns Promise with the result of the operations
      */
-    setMyCommands: (commands: Commands<C>) => Promise<void>;
+    setMyCommands: (commands: Commands<C>, ...rest : Commands <C>[]) => Promise<void>;
     /**
      * Returns the nearest command to the user input.
      * If no command is found, returns `null`.
@@ -30,18 +30,21 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
  */
 export function commands<C extends Context>() {
     return (ctx: CommandsFlavor<C>, next: NextFunction) => {
-        ctx.setMyCommands = async (commands) => {
+        ctx.setMyCommands = async (commands, ...moreCommands : Commands<C>[]) => {
             if (!ctx.chat) {
                 throw new Error(
                     "cannot call `ctx.setMyCommands` on an update with no `chat` property",
                 );
             }
 
-            await Promise.all(
-                commands
-                    .toSingleScopeArgs({ type: "chat", chat_id: ctx.chat.id })
-                    .map((args) => ctx.api.raw.setMyCommands(args)),
-            );
+            const commandsMixin = [commands].concat(moreCommands).values()
+            for(const commands of commandsMixin){
+                await Promise.all(
+                    commands
+                        .toSingleScopeArgs({ type: "chat", chat_id: ctx.chat.id })
+                        .map((args) => ctx.api.raw.setMyCommands(args)),
+                );
+            }
         };
 
         ctx.getNearestCommand = (commands, options) => {


### PR DESCRIPTION
Add ability to do, e.g: 
```js
await c.setMyCommands(userCommands, adminCommands)
```
Might be too rudimentary of an implementation?