### PR TITLE
fix: localization command names being empty

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -204,7 +204,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
      * ```ts
      * bot
      *  .filter(
-     *    Command.hasCommand(/\/delete_(.*)/),
+     *    Command.hasCommand(/delete_(.*)/),
      *    (ctx) => ctx.reply(`Deleting ${ctx.message?.text?.split("_")[1]}`)
      *  )
      * ```
@@ -268,7 +268,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
         description: string,
     ) {
         this._languages.set(languageCode, {
-            name: new RegExp(name),
+            name: name,
             description,
         });
         return this;
@@ -303,7 +303,9 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
     public toObject(languageCode = "default"): BotCommand {
         const localizedName = this.getLocalizedName(languageCode);
         return {
-            command: localizedName instanceof RegExp ? "" : localizedName,
+            command: localizedName instanceof RegExp
+                ? localizedName.source
+                : localizedName,
             description: this.getLocalizedDescription(languageCode),
         };
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -134,10 +134,8 @@ export class Commands<C extends Context> {
         this._commands.push(command);
         return command;
     }
-
     /**
      * Serializes the commands into multiple objects that can each be passed to a `setMyCommands` call.
-     *
      * @returns One item for each combination of command + scope + language
      */
     public toArgs() {
@@ -151,9 +149,8 @@ export class Commands<C extends Context> {
                     language_code: language === "default"
                         ? undefined
                         : language,
-                    commands: commands.map((command) =>
-                        command.toObject(language)
-                    )
+                    commands: commands
+                        .map((command) => command.toObject(language))
                         .filter((args) => args.command.length > 0),
                 });
             }
@@ -171,17 +168,16 @@ export class Commands<C extends Context> {
     public toSingleScopeArgs(scope: BotCommandScope) {
         this._populateMetadata();
         const params: SetMyCommandsParams[] = [];
-
         for (const language of this._languages) {
             params.push({
                 scope,
                 language_code: language === "default" ? undefined : language,
                 commands: this._commands
                     .filter((command) => command.scopes.length)
+                    .filter((command) => typeof command.name === "string")
                     .map((command) => command.toObject(language)),
             });
         }
-
         return params;
     }
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -43,4 +43,92 @@ describe("Commands", () => {
             );
         });
     });
+    describe("setMyCommands utils", () => {
+        describe("toSingleScopeArgs", () => {
+            it("should omit regex commands", () => {
+                const commands = new Commands();
+                commands.command("test", "handler1", (_) => _);
+                commands.command("test2", "handler2", (_) => _);
+                commands.command(/omitMe_\d\d/, "handler3", (_) => _);
+                const params = commands.toSingleScopeArgs({
+                    type: "chat",
+                    chat_id: 10,
+                });
+                assertEquals(params, [
+                    {
+                        scope: { type: "chat", chat_id: 10 },
+                        language_code: undefined,
+                        commands: [
+                            { command: "test", description: "handler1" },
+                            { command: "test2", description: "handler2" },
+                        ],
+                    },
+                ]);
+            });
+            it("should return an array with the localized versions of commands", () => {
+                const commands = new Commands();
+                commands.command("test", "handler1", (_) => _).localize(
+                    "es",
+                    "prueba1",
+                    "resolvedor1",
+                );
+                commands.command("test2", "handler2", (_) => _);
+                commands.command(/omitMe_\d\d/, "handler3", (_) => _).localize(
+                    "es",
+                    /omiteme_\d/,
+                    "resolvedor3",
+                );
+
+                const params = commands.toSingleScopeArgs({
+                    type: "chat",
+                    chat_id: 10,
+                });
+                assertEquals(params, [
+                    {
+                        scope: { type: "chat", chat_id: 10 },
+                        language_code: undefined,
+                        commands: [
+                            { command: "test", description: "handler1" },
+                            { command: "test2", description: "handler2" },
+                        ],
+                    },
+                    {
+                        scope: {
+                            chat_id: 10,
+                            type: "chat",
+                        },
+                        language_code: "es",
+                        commands: [
+                            {
+                                command: "prueba1",
+                                description: "resolvedor1",
+                            },
+                            {
+                                command: "test2",
+                                description: "handler2",
+                            },
+                        ],
+                    },
+                ]);
+            });
+            it("should omit commands with no handler", () => {
+                const commands = new Commands();
+                commands.command("test", "handler", (_) => _);
+                commands.command("omitme", "nohandler");
+                const params = commands.toSingleScopeArgs({
+                    type: "chat",
+                    chat_id: 10,
+                });
+                assertEquals(params, [
+                    {
+                        scope: { type: "chat", chat_id: 10 },
+                        language_code: undefined,
+                        commands: [
+                            { command: "test", description: "handler" },
+                        ],
+                    },
+                ]);
+            });
+        });
+    });
 });

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -54,5 +54,30 @@ describe("Jaro-Wrinkler Algorithm", () => {
 
             assertEquals(fuzzyMatch("xyz", cmds, {}), null);
         });
+
+        it("should work for simple regex commands", () => {
+            const cmds = new Commands<Context>();
+            cmds.command(
+                /magical_\d/,
+                "Magical Command",
+            ).addToScope(
+                { type: "all_private_chats" },
+                (ctx) => ctx.reply(`Hello, ${ctx.chat.first_name}!`),
+            );
+            assertEquals(fuzzyMatch("magcal", cmds, {}), "magical_\\d");
+        });
+        it("should work for localized regex", () => {
+            const cmds = new Commands<Context>();
+            cmds.command(
+                /magical_(a|b)/,
+                "Magical Command",
+            ).addToScope(
+                { type: "all_private_chats" },
+                (ctx) => ctx.reply(`Hello, ${ctx.chat.first_name}!`),
+            ).localize("es", /magico_(c|d)/, "Comando Mágico");
+
+            assertEquals(fuzzyMatch("magici_c", cmds, {}), "magico_(c|d)");
+            assertEquals(fuzzyMatch("magici_a", cmds, {}), "magical_(a|b)");
+        });
     });
 });


### PR DESCRIPTION
fixes #13 by removing regExp conversion to, and type support from _lenguages set in Command class:
output quoted in the issue now looks like:
```js
[
  {
    scope: { type: "chat", chat_id: 333649403 },
    language_code: undefined,
    commands: [
      { command: "start", description: "init bot" },
      { command: "end", description: "end" }
    ]
  },
  {
    scope: { type: "chat", chat_id: 333649403 },
    language_code: "es",
    commands: [
      { command: "iniciar", description: "Inicializa el bot" },
      { command: "fin", description: "finaliza" }
    ]
  }
]
```
other functionality is not broken