### PR TITLE
feat: add mixin of commands on ctx

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -258,7 +258,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
      *  .localize("pt", "iniciar", "Inicia a configuração do bot")
      * ```
      *
-     * @param languageCode Language this translation applies to
+     * @param languageCode Language this translation applies to. @see https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
      * @param name Localized command name
      * @param description Localized command description
      */

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -10,7 +10,7 @@ import {
 } from "./deps.deno.ts";
 import { CommandOptions } from "./types.ts";
 
-type SetMyCommandsParams = {
+export type SetMyCommandsParams = {
     /**
      * Scope
      */
@@ -149,8 +149,9 @@ export class Commands<C extends Context> {
                     language_code: language === "default"
                         ? undefined
                         : language,
-                    commands: commands
-                        .map((command) => command.toObject(language))
+                    commands: commands.map((command) =>
+                        command.toObject(language)
+                    )
                         .filter((args) => args.command.length > 0),
                 });
             }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,6 +13,7 @@ import { CommandOptions } from "./types.ts";
 export type SetMyCommandsParams = {
     /**
      * Scope
+     * @param language_code two letter abbreviation in ISO_639 standard: https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
      */
     scope?: BotCommandScope;
     language_code?: string;

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,7 @@
 import { Commands } from "./commands.ts";
 import { Context, NextFunction } from "./deps.deno.ts";
 import { fuzzyMatch, JaroWinklerOptions } from "./jaro-winkler.ts";
+import { SetMyCommandsParams } from "./mod.ts";
 
 export interface CommandsFlavor<C extends Context = Context> extends Context {
     /**
@@ -10,7 +11,10 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
      * @param commands List of available commands
      * @returns Promise with the result of the operations
      */
-    setMyCommands: (commands: Commands<C>) => Promise<void>;
+    setMyCommands: (
+        commands: Commands<C>,
+        ...moreCommands: Commands<C>[]
+    ) => Promise<void>;
     /**
      * Returns the nearest command to the user input.
      * If no command is found, returns `null`.
@@ -30,16 +34,26 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
  */
 export function commands<C extends Context>() {
     return (ctx: CommandsFlavor<C>, next: NextFunction) => {
-        ctx.setMyCommands = async (commands) => {
+        ctx.setMyCommands = async (
+            commands,
+            ...moreCommands: Commands<C>[]
+        ) => {
             if (!ctx.chat) {
                 throw new Error(
                     "cannot call `ctx.setMyCommands` on an update with no `chat` property",
                 );
             }
+            const commandsParams = [commands].concat(moreCommands).map((
+                commands,
+            ) => commands.toSingleScopeArgs({
+                type: "chat",
+                chat_id: ctx.chat!.id,
+            }));
+
+            const mergedCommands = mergeMyCommandsParams(commandsParams);
 
             await Promise.all(
-                commands
-                    .toSingleScopeArgs({ type: "chat", chat_id: ctx.chat.id })
+                mergedCommands
                     .map((args) => ctx.api.raw.setMyCommands(args)),
             );
         };
@@ -54,4 +68,36 @@ export function commands<C extends Context>() {
 
         return next();
     };
+}
+
+/**
+ * Iterates over an array of commands params, merging commands when two commandsParams
+ * are from the same language.
+ *
+ * @param commandParams an array of commands params coming from multiple Commands instances
+ * @returns an array containing all commands to be set on ctx
+ */
+
+function mergeMyCommandsParams(
+    commandParams: SetMyCommandsParams[][],
+): SetMyCommandsParams[] {
+    if (!commandParams.flat().length) return [];
+    return commandParams
+        .flat()
+        .sort((a, b) => {
+            if (!a.language_code) return -1;
+            if (!b.language_code) return 1;
+            return a.language_code.localeCompare(b.language_code);
+        })
+        .reduce((result, current, i, arr) => {
+            if (i === 0 || current.language_code !== arr[i - 1].language_code) {
+                result.push(current);
+                return result;
+            } else {
+                result[result.length - 1].commands = result[result.length - 1]
+                    .commands
+                    .concat(current.commands);
+                return result;
+            }
+        }, [] as SetMyCommandsParams[]);
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -50,7 +50,7 @@ export function commands<C extends Context>() {
                 chat_id: ctx.chat!.id,
             }));
 
-            const mergedCommands = mergeMyCommandsParams(commandsParams);
+            const mergedCommands = _mergeMyCommandsParams(commandsParams);
 
             await Promise.all(
                 mergedCommands
@@ -78,7 +78,7 @@ export function commands<C extends Context>() {
  * @returns an array containing all commands to be set on ctx
  */
 
-function mergeMyCommandsParams(
+export function _mergeMyCommandsParams(
     commandParams: SetMyCommandsParams[][],
 ): SetMyCommandsParams[] {
     if (!commandParams.flat().length) return [];


### PR DESCRIPTION
## Summary
- #14  is built into this pr (please check that out first)
- changed the ```setMyCommands``` function to be able to merge ```SetMyCommandsParams``` from two or more different sources, based on the fact that ```toSingleScopeArgs``` group them by language. Merge function its basically a reducer that concat ```lang.commands``` arrays of the same language and returns an array of ```setMyCommandsParams```. It does not break scoping since it's performed after the ```toSingleScopeArgs``` function. If an empty array is passed, it does not throw, if only  one Commands instance is passed it treats it ok.
     - the name of the ```result``` variable might be better to change it to ```acc_Array``` or something in those lines
 - add info jsdoc info about lang's iso codes (an enum would be ideal 👍 )

PD: I closed the other PR since it was a little messy on the branch managment end, this one is ok.
PD2: I can refactor this into a MixedCommands class that extends the Commands Class if that suits more the style. 
Another way would be to add this as a method to the Commands Class, but I don't know good of an idea would be to mix them before ```toSingleScopeArgs``` in a method like ```commands.mergeWith(otherCommands)``` because it would effectively duplicate commands registration if someone use it on let say commands A and B, and register both into ```bot.use```,  registering all at once on A (B was merged into A), and then re-register B commands. Even in that case they would simply overwrite themselves I think so, no? 

eg:

![pr webm](https://github.com/grammyjs/commands/assets/48109042/b24445c4-bd86-4d28-b5b7-61819068284e)

snippet from the gif (localization in the admin command... 🥴) 
```ts
// localized start command //
userCommands.command("end", "end", async (c) => {
  await c.setMyCommands(userCommands)
}).localize("es", "fin", "finaliza")
  .addToScope(
    { type: "all_private_chats" },
    async (ctx) => {
      ctx.reply(`finalizado`)
      await ctx.setMyCommands(userCommands)
    },
  );
adminCommands.command("admin", "i am the admin", async (c) => {
  await c.setMyCommands(userCommands, adminCommands);
}).localize("es", "start", "el admin soy yo");
```