### PR TITLE
chore: Improve getNearestCommands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.7.0",
             "license": "MIT",
             "dependencies": {
+                "@grammyjs/types": "^3.8.1",
                 "grammy": "^1.17.1",
                 "ts-pattern": "^5.0.1"
             },
@@ -17,9 +18,9 @@
             }
         },
         "node_modules/@grammyjs/types": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.1.2.tgz",
-            "integrity": "sha512-AsSkTUfZCfSEIacUBOQ94qLbZZy3UofkschWv4uBJKEHjuEfGnjeZZgiwhDfTDjmpmW+MbcasvS+FEfD2jiSLw=="
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.8.1.tgz",
+            "integrity": "sha512-2atGlWCgvSrJr+xDJBzVvCS4DT7LE/Yxim1lmGdSaYjyh968U1tKpDv8NK8qs+V9xnMtwxmId2W1h2Oc8J6ShA=="
         },
         "node_modules/abort-controller": {
             "version": "3.0.0",
@@ -69,6 +70,11 @@
             "engines": {
                 "node": "^12.20.0 || >=14.13.1"
             }
+        },
+        "node_modules/grammy/node_modules/@grammyjs/types": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.1.2.tgz",
+            "integrity": "sha512-AsSkTUfZCfSEIacUBOQ94qLbZZy3UofkschWv4uBJKEHjuEfGnjeZZgiwhDfTDjmpmW+MbcasvS+FEfD2jiSLw=="
         },
         "node_modules/ms": {
             "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "author": "Roz <roz@rjmunhoz.me>",
     "license": "MIT",
     "dependencies": {
+        "@grammyjs/types": "^3.8.1",
         "grammy": "^1.17.1",
         "ts-pattern": "^5.0.1"
     },

--- a/src/command.ts
+++ b/src/command.ts
@@ -97,6 +97,13 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
     }
 
     /**
+     * Get the prefix for this command
+     */
+    get prefix() {
+        return this._options.prefix;
+    }
+
+    /**
      * Registers the command to a scope to allow it to be handled and used with `setMyCommands`.
      * This will automatically apply filtering middlewares for you, so the handler only runs on the specified scope.
      *

--- a/src/command.ts
+++ b/src/command.ts
@@ -7,6 +7,7 @@ import {
     type ChatTypeMiddleware,
     Composer,
     type Context,
+    type LanguageCode,
     type Middleware,
     type MiddlewareObj,
 } from "./deps.deno.ts";
@@ -32,7 +33,7 @@ export const matchesPattern = (value: string, pattern: string | RegExp) =>
 export class Command<C extends Context = Context> implements MiddlewareObj<C> {
     private _scopes: BotCommandScope[] = [];
     private _languages: Map<
-        string,
+        LanguageCode | "default",
         { name: string | RegExp; description: string }
     > = new Map();
     private _composer: Composer<C> = new Composer<C>();
@@ -266,7 +267,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
      * @param description Localized command description
      */
     public localize(
-        languageCode: string,
+        languageCode: LanguageCode,
         name: string | RegExp,
         description: string,
     ) {
@@ -282,7 +283,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
      * @param languageCode Language to get the name for
      * @returns Localized command name
      */
-    public getLocalizedName(languageCode: string) {
+    public getLocalizedName(languageCode: LanguageCode | "default") {
         return this._languages.get(languageCode)?.name ?? this.name;
     }
 
@@ -291,7 +292,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
      * @param languageCode Language to get the name for
      * @returns Localized command name
      */
-    public getLocalizedDescription(languageCode: string) {
+    public getLocalizedDescription(languageCode: LanguageCode | "default") {
         return this._languages.get(languageCode)?.description ??
             this.description;
     }
@@ -303,7 +304,9 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
      * @param languageCode If specified, uses localized versions of the command name and description
      * @returns Object representation of this command
      */
-    public toObject(languageCode = "default"): BotCommand {
+    public toObject(
+        languageCode: LanguageCode | "default" = "default",
+    ): BotCommand {
         const localizedName = this.getLocalizedName(languageCode);
         return {
             command: localizedName instanceof RegExp

--- a/src/command.ts
+++ b/src/command.ts
@@ -11,7 +11,7 @@ import {
     type MiddlewareObj,
 } from "./deps.deno.ts";
 import { InvalidScopeError } from "./errors.ts";
-import { CommandOptions } from "./types.ts";
+import type { CommandOptions } from "./types.ts";
 import { ensureArray, type MaybeArray } from "./utils.ts";
 
 type BotCommandGroupsScope =

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -204,9 +204,9 @@ export class Commands<C extends Context> {
 
     /**
      * Serialize all register commands into an array of {@link CommandElementals},
-     * each registered command would be summarize into it's name, prefix and language
+     * each registered command will be summarized into it's name, prefix and language
      *
-     * @param filterLanguage if given and valid, it would filter all command localizations
+     * @param filterLanguage If given and valid, filters out all command localizations
      * that not match the filterLanguage,
      * if a command does not have the given language, it would fallback to "default"
      *

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,7 +13,7 @@ import type { CommandElementals, CommandOptions } from "./types.ts";
 import { type MaybeArray } from "./utils.ts";
 
 /**
- * Interface for grouping {@link BotCommand}'s that might (or not)
+ * Interface for grouping {@link BotCommand}s that might (or not)
  * be related to each other by scope and/or language.
  */
 export type SetMyCommandsParams = {

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,11 @@
 import { ensureArray } from "./utils.ts";
 import { Commands } from "./commands.ts";
 import { BotCommandScopeChat, Context, NextFunction } from "./deps.deno.ts";
-import { fuzzyMatch, JaroWinklerOptions } from "./jaro-winkler.ts";
+import {
+    CommandNameAndPrefix,
+    fuzzyMatch,
+    JaroWinklerOptions,
+} from "./jaro-winkler.ts";
 import { SetMyCommandsParams } from "./mod.ts";
 
 export interface CommandsFlavor<C extends Context = Context> extends Context {
@@ -37,7 +41,7 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
     getNearestCommand: (
         commands: Commands<C>,
         options?: Partial<JaroWinklerOptions>,
-    ) => string | null;
+    ) => CommandNameAndPrefix | null;
 }
 
 /**
@@ -63,9 +67,9 @@ export function commands<C extends Context>() {
         };
 
         ctx.getNearestCommand = (commands, options) => {
-            if (ctx.msg?.text) {
+            if (ctx.msg?.text && ctx.from?.language_code) {
                 const userInput = ctx.msg.text.substring(1);
-                return fuzzyMatch(userInput, commands, { ...options });
+                return fuzzyMatch(userInput, commands, { ...options, language: ctx.from.language_code });
             }
             return null;
         };

--- a/src/context.ts
+++ b/src/context.ts
@@ -69,10 +69,8 @@ export function commands<C extends Context>() {
                     const userInput = ctx.msg!.text!.substring(1);
                     const result = fuzzyMatch(userInput, commands, {
                         ...options,
-                        language: options?.ignoreLocalization
-                            ? undefined
-                            : ctx.from?.language_code
-                            ? ctx.from.language_code
+                        language: !options?.ignoreLocalization
+                            ? ctx.from?.language_code
                             : undefined,
                     });
                     return result;

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,7 +2,6 @@ import { ensureArray } from "./utils.ts";
 import { Commands } from "./commands.ts";
 import { BotCommandScopeChat, Context, NextFunction } from "./deps.deno.ts";
 import {
-    CommandNameAndPrefix,
     fuzzyMatch,
     JaroWinklerOptions,
 } from "./jaro-winkler.ts";
@@ -41,7 +40,7 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
     getNearestCommand: (
         commands: Commands<C>,
         options?: Partial<JaroWinklerOptions>,
-    ) => CommandNameAndPrefix | null;
+    ) => string | null;
 }
 
 /**
@@ -69,7 +68,10 @@ export function commands<C extends Context>() {
         ctx.getNearestCommand = (commands, options) => {
             if (ctx.msg?.text && ctx.from?.language_code) {
                 const userInput = ctx.msg.text.substring(1);
-                return fuzzyMatch(userInput, commands, { ...options, language: ctx.from.language_code });
+                const result = fuzzyMatch(userInput, commands, { ...options, language: ctx.from.language_code });
+                if(!result) return result;
+
+                return result.prefix + result.name
             }
             return null;
         };

--- a/src/context.ts
+++ b/src/context.ts
@@ -63,11 +63,15 @@ export function commands<C extends Context>() {
         };
 
         ctx.getNearestCommand = (commands, options) => {
-            if (ctx.msg?.text && ctx.from?.language_code) {
+            if (ctx.msg?.text) {
                 const userInput = ctx.msg.text.substring(1);
                 const result = fuzzyMatch(userInput, commands, {
                     ...options,
-                    language: ctx.from.language_code,
+                    language: options?.ignoreLocalization
+                        ? undefined
+                        : ctx.from?.language_code
+                        ? ctx.from.language_code
+                        : undefined,
                 });
                 if (!result) return result;
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -36,7 +36,7 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
      */
     getNearestCommand: (
         commands: Commands<C>,
-        options?: Partial<JaroWinklerOptions>,
+        options?: Omit<Partial<JaroWinklerOptions>, "language">,
     ) => string | null;
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,10 +1,7 @@
 import { ensureArray } from "./utils.ts";
 import { Commands } from "./commands.ts";
 import { BotCommandScopeChat, Context, NextFunction } from "./deps.deno.ts";
-import {
-    fuzzyMatch,
-    JaroWinklerOptions,
-} from "./jaro-winkler.ts";
+import { fuzzyMatch, JaroWinklerOptions } from "./jaro-winkler.ts";
 import { SetMyCommandsParams } from "./mod.ts";
 
 export interface CommandsFlavor<C extends Context = Context> extends Context {
@@ -68,10 +65,13 @@ export function commands<C extends Context>() {
         ctx.getNearestCommand = (commands, options) => {
             if (ctx.msg?.text && ctx.from?.language_code) {
                 const userInput = ctx.msg.text.substring(1);
-                const result = fuzzyMatch(userInput, commands, { ...options, language: ctx.from.language_code });
-                if(!result) return result;
+                const result = fuzzyMatch(userInput, commands, {
+                    ...options,
+                    language: ctx.from.language_code,
+                });
+                if (!result) return result;
 
-                return result.prefix + result.name
+                return result.prefix + result.name;
             }
             return null;
         };

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -19,4 +19,8 @@ export type {
     BotCommandScopeAllPrivateChats,
     BotCommandScopeChat,
     Chat,
-} from "https://lib.deno.dev/x/grammy@1/types.ts";
+    LanguageCode,
+} from "https://lib.deno.dev/x/grammy_types@^v3.8.1/mod.ts";
+export {
+    LanguageCodes,
+} from "https://lib.deno.dev/x/grammy_types@^v3.8.1/mod.ts";

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -19,4 +19,7 @@ export type {
     BotCommandScopeAllPrivateChats,
     BotCommandScopeChat,
     Chat,
-} from "grammy/types";
+    LanguageCode,
+} from "@grammyjs/types";
+
+export { LanguageCodes } from "@grammyjs/types";

--- a/src/jaro-winkler.ts
+++ b/src/jaro-winkler.ts
@@ -1,6 +1,5 @@
-import { SetMyCommandsParams } from "./commands.ts";
 import { Commands } from "./commands.ts";
-import { BotCommandScope, Context } from "./deps.deno.ts";
+import { Context } from "./deps.deno.ts";
 
 export function distance(s1: string, s2: string) {
     if (s1.length === 0 || s2.length === 0) {
@@ -78,11 +77,11 @@ export type JaroWinklerOptions = {
 };
 
 type CommandSimilarity = {
-    command: CommandNameAndPrefix | null;
+    command: CommandElementals | null;
     similarity: number;
 };
 
-export interface CommandNameAndPrefix {
+export interface CommandElementals {
     name: string;
     prefix: string;
     language: string;
@@ -123,7 +122,7 @@ export function fuzzyMatch<C extends Context>(
     userInput: string,
     commands: Commands<C>,
     options: Partial<JaroWinklerOptions>,
-): CommandNameAndPrefix | null {
+): CommandSimilarity | null {
     const defaultSimilarityThreshold = 0.82;
     const similarityThreshold = options.similarityThreshold ||
         defaultSimilarityThreshold;
@@ -131,8 +130,8 @@ export function fuzzyMatch<C extends Context>(
     options.language ??= "default";
 
     const cmds = options.ignoreLocalization
-        ? commands.toNameAndPrefix()
-        : commands.toNameAndPrefix(options.language);
+        ? commands.toElementals()
+        : commands.toElementals(options.language);
 
     const bestMatch = cmds.reduce(
         (best: CommandSimilarity, command) => {
@@ -146,7 +145,5 @@ export function fuzzyMatch<C extends Context>(
         { command: null, similarity: 0 },
     );
 
-    return bestMatch.similarity > similarityThreshold
-        ? bestMatch.command
-        : null;
+    return bestMatch.similarity > similarityThreshold ? bestMatch : null;
 }

--- a/src/jaro-winkler.ts
+++ b/src/jaro-winkler.ts
@@ -135,7 +135,7 @@ export function fuzzyMatch<C extends Context>(
     const possiblyISO639 = options.language?.split("-")[0];
     const language = isLanguageCode(possiblyISO639)
         ? possiblyISO639
-        : "default";
+        : undefined;
 
     const cmds = options.ignoreLocalization
         ? commands.toElementals()

--- a/src/jaro-winkler.ts
+++ b/src/jaro-winkler.ts
@@ -84,6 +84,7 @@ type CommandSimilarity = {
 export interface CommandElementals {
     name: string;
     prefix: string;
+    // scope: BotCommandScope["type"]
     language: string;
 }
 
@@ -96,7 +97,7 @@ export interface CommandElementals {
 export function JaroWinklerDistance(
     s1: string,
     s2: string,
-    options: Partial<JaroWinklerOptions>,
+    options: Pick<Partial<JaroWinklerOptions>, "ignoreCase">,
 ) {
     if (s1 === s2) {
         return 1;

--- a/src/jaro-winkler.ts
+++ b/src/jaro-winkler.ts
@@ -1,3 +1,4 @@
+import { SetMyCommandsParams } from "./commands.ts";
 import { Commands } from "./commands.ts";
 import { BotCommandScope, Context } from "./deps.deno.ts";
 
@@ -73,6 +74,7 @@ export type JaroWinklerOptions = {
     ignoreCase?: boolean;
     similarityThreshold?: number;
     language?: string;
+    ignoreLocalization?: boolean;
 };
 
 type CommandSimilarity = {
@@ -83,6 +85,7 @@ type CommandSimilarity = {
 export interface CommandNameAndPrefix {
     name: string;
     prefix: string;
+    language: string;
 }
 
 // Computes the Winkler distance between two string -- intrepreted from:
@@ -125,8 +128,11 @@ export function fuzzyMatch<C extends Context>(
     const similarityThreshold = options.similarityThreshold ||
         defaultSimilarityThreshold;
 
-    const cmds = commands
-        .toNameAndPrefix(options.language);
+    options.language ??= "default";
+
+    const cmds = options.ignoreLocalization
+        ? commands.toNameAndPrefix()
+        : commands.toNameAndPrefix(options.language);
 
     const bestMatch = cmds.reduce(
         (best: CommandSimilarity, command) => {

--- a/src/jaro-winkler.ts
+++ b/src/jaro-winkler.ts
@@ -1,5 +1,6 @@
 import { Commands } from "./commands.ts";
 import { Context } from "./deps.deno.ts";
+import type { CommandElementals } from "./types.ts";
 
 export function distance(s1: string, s2: string) {
     if (s1.length === 0 || s2.length === 0) {
@@ -81,13 +82,6 @@ type CommandSimilarity = {
     similarity: number;
 };
 
-export interface CommandElementals {
-    name: string;
-    prefix: string;
-    // scope: BotCommandScope["type"]
-    language: string;
-}
-
 // Computes the Winkler distance between two string -- intrepreted from:
 // http://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance
 // s1 is the first string to compare
@@ -127,8 +121,6 @@ export function fuzzyMatch<C extends Context>(
     const defaultSimilarityThreshold = 0.82;
     const similarityThreshold = options.similarityThreshold ||
         defaultSimilarityThreshold;
-
-    options.language ??= "default";
 
     const cmds = options.ignoreLocalization
         ? commands.toElementals()

--- a/src/jaro-winkler.ts
+++ b/src/jaro-winkler.ts
@@ -133,7 +133,9 @@ export function fuzzyMatch<C extends Context>(
      * https://en.wikipedia.org/wiki/IETF_language_tag
      */
     const possiblyISO639 = options.language?.split("-")[0];
-    const language = isLanguageCode(possiblyISO639) ? possiblyISO639 : "default";
+    const language = isLanguageCode(possiblyISO639)
+        ? possiblyISO639
+        : "default";
 
     const cmds = options.ignoreLocalization
         ? commands.toElementals()

--- a/src/jaro-winkler.ts
+++ b/src/jaro-winkler.ts
@@ -121,7 +121,7 @@ export function fuzzyMatch<C extends Context>(
     commands: Commands<C>,
     options: Partial<JaroWinklerOptions>,
 ): CommandNameAndPrefix | null {
-    const defaultSimilarityThreshold = 0.85;
+    const defaultSimilarityThreshold = 0.82;
     const similarityThreshold = options.similarityThreshold ||
         defaultSimilarityThreshold;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,3 +22,9 @@ export interface CommandOptions {
      */
     targetedCommands: "ignored" | "optional" | "required";
 }
+
+export interface CommandElementals {
+    name: string;
+    prefix: string;
+    language: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { LanguageCode } from "./deps.deno.ts";
+
 /**
  * Supported command options
  */
@@ -26,5 +28,5 @@ export interface CommandOptions {
 export interface CommandElementals {
     name: string;
     prefix: string;
-    language: string;
+    language: LanguageCode | "default";
 }

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -13,28 +13,28 @@ import {
 } from "./deps.test.ts";
 
 describe("commands", () => {
-
     it("should install the setMyCommands method on the context", () => {
-        const context = dummyCtx({})
+        const context = dummyCtx({});
 
         const middleware = commands();
-        middleware(context, async () => { });
+        middleware(context, async () => {});
 
         assert(context.setMyCommands);
     });
     it("should install the getNearestCommand method on the context", () => {
-        const context = dummyCtx({})
+        const context = dummyCtx({});
 
         const middleware = commands();
-        middleware(context, async () => { });
+        middleware(context, async () => {});
 
         assert(context.getNearestCommand);
     });
 });
 
-
 export function dummyCtx({ userInput, language, noChat }: {
-    userInput?: string, language?: string, noChat?: boolean
+    userInput?: string;
+    language?: string;
+    noChat?: boolean;
 }) {
     const u = { id: 42, first_name: "yo", language_code: language } as User;
     const c = { id: 100, type: "private" } as Chat;
@@ -50,6 +50,6 @@ export function dummyCtx({ userInput, language, noChat }: {
     const me = { id: 42, username: "bot" } as UserFromGetMe;
     const ctx = new Context(update, api, me) as CommandsFlavor<Context>;
     const middleware = commands();
-    middleware(ctx, async () => { });
+    middleware(ctx, async () => {});
     return ctx;
 }

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -13,53 +13,43 @@ import {
 } from "./deps.test.ts";
 
 describe("commands", () => {
-    const u = { id: 42, first_name: "bot", is_bot: true } as User;
-    const c = { id: 100, type: "private" } as Chat;
-    const m = { text: "a", from: u, chat: c, sender_chat: c } as Message;
-    const update = {
-        message: m,
-        edited_message: m,
-        channel_post: m,
-        edited_channel_post: m,
-        inline_query: { id: "b", from: u, query: "iq" },
-        chosen_inline_result: {
-            from: u,
-            inline_message_id: "x",
-            result_id: "p",
-        },
-        callback_query: {
-            data: "cb",
-            game_short_name: "game",
-            message: m,
-            from: u,
-            inline_message_id: "y",
-        },
-        shipping_query: { id: "d", from: u },
-        pre_checkout_query: { id: "e", from: u },
-        poll: { id: "f" },
-        poll_answer: { poll_id: "g" },
-        my_chat_member: { date: 1, from: u, chat: c },
-        chat_member: { date: 2, from: u, chat: c },
-        chat_join_request: { date: 3, from: u, chat: c },
-    } as Update;
-
-    const api = new Api("dummy-token");
-    const me = { id: 42, username: "bot" } as UserFromGetMe;
 
     it("should install the setMyCommands method on the context", () => {
-        const context = new Context(update, api, me) as CommandsFlavor<Context>;
+        const context = dummyCtx({})
 
         const middleware = commands();
-        middleware(context, async () => {});
+        middleware(context, async () => { });
 
         assert(context.setMyCommands);
     });
     it("should install the getNearestCommand method on the context", () => {
-        const context = new Context(update, api, me) as CommandsFlavor<Context>;
+        const context = dummyCtx({})
 
         const middleware = commands();
-        middleware(context, async () => {});
+        middleware(context, async () => { });
 
         assert(context.getNearestCommand);
     });
 });
+
+
+export function dummyCtx({ userInput, language, noChat }: {
+    userInput?: string, language?: string, noChat?: boolean
+}) {
+    const u = { id: 42, first_name: "yo", language_code: language } as User;
+    const c = { id: 100, type: "private" } as Chat;
+    const m = {
+        text: userInput,
+        from: u,
+        chat: noChat ? undefined : c,
+    } as Message;
+    const update = {
+        message: m,
+    } as Update;
+    const api = new Api("dummy-token");
+    const me = { id: 42, username: "bot" } as UserFromGetMe;
+    const ctx = new Context(update, api, me) as CommandsFlavor<Context>;
+    const middleware = commands();
+    middleware(ctx, async () => { });
+    return ctx;
+}

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -106,43 +106,82 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 assertEquals(json[1].name, "duque");
             });
         });
-        describe('Should return the command localization related to the user lang', () => {
+        describe("Should return the command localization related to the user lang", () => {
             const cmds = new Commands<Context>();
-            cmds.command('duke', 'sniper', () => { })
-                .localize('es', 'duque', '_')
-                .localize('fr', 'duc', '_')
-                .localize('it', 'duca', '_')
-                .localize('pt', 'duque', '_')
-                .localize('de', 'herzog', '_')
-                .localize('sv', 'hertig', '_')
-                .localize('da', 'hertug', '_')
-                .localize('fi', 'herttua', '_')
-                .localize('hu', 'herceg', '_')
+            cmds.command("duke", "sniper", () => {})
+                .localize("es", "duque", "_")
+                .localize("fr", "duc", "_")
+                .localize("it", "duca", "_")
+                .localize("pt", "duque", "_")
+                .localize("de", "herzog", "_")
+                .localize("sv", "hertig", "_")
+                .localize("da", "hertug", "_")
+                .localize("fi", "herttua", "_")
+                .localize("hu", "herceg", "_");
 
             it("sv", () => {
-                assertEquals(fuzzyMatch('hertog', cmds, {}), "hertig");
+                assertEquals(fuzzyMatch("hertog", cmds, {}), "hertig");
             });
             it("da", () => {
-                assertEquals(fuzzyMatch('hertog', cmds, {}), "hertug");
+                assertEquals(fuzzyMatch("hertog", cmds, {}), "hertug");
             });
-            it("default", () => {
-                assertEquals(fuzzyMatch('duk', cmds, {}), "duke");
-                assertEquals(fuzzyMatch('duka', cmds, {}), "duke");
-                assertEquals(fuzzyMatch('duqa', cmds, {}), "duke");
-                assertEquals(fuzzyMatch('duqe', cmds, {}), "duke");
+            describe("default", () => {
+                it("duke", () =>
+                    assertEquals(fuzzyMatch("duk", cmds, {}), "duke"));
+                it("duke", () =>
+                    assertEquals(fuzzyMatch("due", cmds, {}), "duke"));
+                it("duke", () =>
+                    assertEquals(fuzzyMatch("dule", cmds, {}), "duke"));
+                it("duke", () =>
+                    assertEquals(fuzzyMatch("duje", cmds, {}), "duke"));
             });
-            it("es", () => {
-                assertEquals(fuzzyMatch('duk', cmds, {}), "duque");
-                assertEquals(fuzzyMatch('duke', cmds, {}), "duque");
-                assertEquals(fuzzyMatch('dukue', cmds, {}), "duque");
-                assertEquals(fuzzyMatch('duqe', cmds, {}), "duque");
+            describe("es", () => {
+                it("duque", () =>
+                    assertEquals(fuzzyMatch("duquw", cmds, {}), "duque"));
+                it("duque", () =>
+                    assertEquals(fuzzyMatch("duqe", cmds, {}), "duque"));
+                it("duque", () =>
+                    assertEquals(fuzzyMatch("duwue", cmds, {}), "duque"));
             });
-            it("fr", () => {
-                assertEquals(fuzzyMatch('duk', cmds, {}), "duc");
-                assertEquals(fuzzyMatch('duco', cmds, {}), "duc");
-                assertEquals(fuzzyMatch('duca', cmds, {}), "duc");
-                assertEquals(fuzzyMatch('ducce', cmds, {}), "duc");
+            describe("fr", () => {
+                it("duc", () =>
+                    assertEquals(fuzzyMatch("duk", cmds, {}), "duc"));
+                it("duc", () =>
+                    assertEquals(fuzzyMatch("duce", cmds, {}), "duc"));
+                it("duc", () =>
+                    assertEquals(fuzzyMatch("ducñ", cmds, {}), "duc"));
             });
-        })
+        });
+        describe("Should return the command localization related to the user lang for similar command names from different command classes", () => {
+            const cmds = new Commands<Context>();
+            cmds.command("push", "push", () => {})
+                .localize("fr", "pousser", "_")
+                .localize("pt", "empurrar", "_");
+
+            cmds.command("rest", "rest")
+                .localize("fr", "reposer", "_")
+                .localize("pt", "poussar", "_");
+
+            describe("pt rest", () => {
+                it("poussar", () =>
+                    assertEquals(fuzzyMatch("pousssr", cmds, {}), "poussar"));
+                it("poussar", () =>
+                    assertEquals(fuzzyMatch("pousar", cmds, {}), "poussar"));
+                it("poussar", () =>
+                    assertEquals(fuzzyMatch("poussqr", cmds, {}), "poussar"));
+                it("poussar", () =>
+                    assertEquals(fuzzyMatch("poussrr", cmds, {}), "poussar"));
+            });
+            describe("fr push", () => {
+                it("poussar", () =>
+                    assertEquals(fuzzyMatch("pousssr", cmds, {}), "pousser"));
+                it("poussar", () =>
+                    assertEquals(fuzzyMatch("pouser", cmds, {}), "pousser"));
+                it("poussar", () =>
+                    assertEquals(fuzzyMatch("pousrr", cmds, {}), "pousser"));
+                it("poussar", () =>
+                    assertEquals(fuzzyMatch("poussrr", cmds, {}), "pousser"));
+            });
+        });
     });
 });

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -47,7 +47,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             cmds.command(
                 "start",
                 "Starting",
-                () => { },
+                () => {},
             );
             assertEquals(
                 fuzzyMatch("strt", cmds, { language: "fr" })?.command?.name,
@@ -61,7 +61,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             cmds.command(
                 "start",
                 "Starting",
-                () => { },
+                () => {},
             ).addToScope(
                 { type: "all_private_chats" },
                 (ctx) => ctx.reply(`Hello, ${ctx.chat.first_name}!`),
@@ -107,11 +107,11 @@ describe("Jaro-Wrinkler Algorithm", () => {
     describe("Serialize commands for FuzzyMatch", () => {
         describe("toNameAndPrefix", () => {
             const cmds = new Commands<Context>();
-            cmds.command("butcher", "_", () => { }, { prefix: "?" })
+            cmds.command("butcher", "_", () => {}, { prefix: "?" })
                 .localize("es", "carnicero", "_")
                 .localize("it", "macellaio", "_");
 
-            cmds.command("duke", "_", () => { })
+            cmds.command("duke", "_", () => {})
                 .localize("es", "duque", "_")
                 .localize("fr", "duc", "_");
 
@@ -129,7 +129,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
         describe("Should return the command localization related to the user lang", () => {
             const cmds = new Commands<Context>();
-            cmds.command("duke", "sniper", () => { })
+            cmds.command("duke", "sniper", () => {})
                 .localize("es", "duque", "_")
                 .localize("fr", "duc", "_")
                 .localize("it", "duca", "_")
@@ -219,11 +219,11 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
         describe("Should return the command localization related to the user lang for similar command names from different command classes", () => {
             const cmds = new Commands<Context>();
-            cmds.command("push", "push", () => { })
+            cmds.command("push", "push", () => {})
                 .localize("fr", "pousser", "a")
                 .localize("pt", "empurrar", "b");
 
-            cmds.command("rest", "rest", () => { })
+            cmds.command("rest", "rest", () => {})
                 .localize("fr", "reposer", "c")
                 .localize("pt", "poussar", "d");
 
@@ -283,24 +283,24 @@ describe("Jaro-Wrinkler Algorithm", () => {
     });
     describe("Usage inside ctx", () => {
         const cmds = new Commands<Context>();
-        cmds.command("butcher", "_", () => { }, { prefix: "+" })
+        cmds.command("butcher", "_", () => {}, { prefix: "+" })
             .localize("es", "carnicero", "_")
             .localize("it", "macellaio", "_");
 
-        cmds.command("duke", "_", () => { })
+        cmds.command("duke", "_", () => {})
             .localize("es", "duque", "_")
             .localize("fr", "duc", "_");
 
-        cmds.command("daddy", "me", () => { }, { prefix: "?" })
+        cmds.command("daddy", "me", () => {}, { prefix: "?" })
             .localize("es", "papito", "yeyo");
 
-        cmds.command("ender", "_", () => { });
-        cmds.command("endanger", "_", () => { });
-        cmds.command("entitle", "_", () => { });
+        cmds.command("ender", "_", () => {});
+        cmds.command("endanger", "_", () => {});
+        cmds.command("entitle", "_", () => {});
 
         it("Should return null when no msg is given", () => {
             let ctx = dummyCtx({
-                userInput: ""
+                userInput: "",
             });
             assertEquals(
                 ctx.getNearestCommand(cmds),
@@ -312,7 +312,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             it("ignore even if the language is set", () => { // should this console.warn? or maybe use an overload?
                 let ctx = dummyCtx({
                     userInput: "/duci",
-                    language: "es"
+                    language: "es",
                 });
                 assertEquals(
                     ctx.getNearestCommand(cmds, {
@@ -322,7 +322,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 );
                 ctx = dummyCtx({
                     userInput: "/duki",
-                    language: "es"
+                    language: "es",
                 });
                 assertEquals(
                     ctx.getNearestCommand(cmds, {
@@ -334,7 +334,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             it("ignore when the language is not set", () => {
                 let ctx = dummyCtx({
                     userInput: "/duki",
-                    language: "es"
+                    language: "es",
                 });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
@@ -342,7 +342,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 );
                 ctx = dummyCtx({
                     userInput: "/macellaoo",
-                    language: "es"
+                    language: "es",
                 });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
@@ -350,7 +350,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 );
                 ctx = dummyCtx({
                     userInput: "/dadd",
-                    language: "es"
+                    language: "es",
                 });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
@@ -358,7 +358,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 );
                 ctx = dummyCtx({
                     userInput: "/duk",
-                    language: "es"
+                    language: "es",
                 });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
@@ -368,7 +368,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             it("should not restrict itself to default", () => {
                 let ctx = dummyCtx({
                     userInput: "/duqu",
-                    language: "es"
+                    language: "es",
                 });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
@@ -378,7 +378,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             it("language not know, but ignore localization still matches the best similarity", () => {
                 let ctx = dummyCtx({
                     userInput: "/duqu",
-                    language: "en-papacito"
+                    language: "en-papacito",
                 });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
@@ -388,7 +388,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             it("should chose localization if not ignore", () => {
                 let ctx = dummyCtx({
                     userInput: "/duku",
-                    language: "es"
+                    language: "es",
                 });
                 assertEquals(
                     ctx.getNearestCommand(cmds),
@@ -396,7 +396,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 );
                 ctx = dummyCtx({
                     userInput: "/duk",
-                    language: "fr"
+                    language: "fr",
                 });
                 assertEquals(
                     ctx.getNearestCommand(cmds),
@@ -408,19 +408,19 @@ describe("Jaro-Wrinkler Algorithm", () => {
             it("should fallback to default", () => {
                 let ctx = dummyCtx({
                     userInput: "/duko",
-                    language: "en-papacito"
+                    language: "en-papacito",
                 });
                 assertEquals(ctx.getNearestCommand(cmds), "/duke");
                 ctx = dummyCtx({
                     userInput: "/butxher",
-                    language: "no-language"
+                    language: "no-language",
                 });
                 assertEquals(ctx.getNearestCommand(cmds), "+butcher");
             });
             it("should not fallback to a locale even if its the same name", () => {
                 let ctx = dummyCtx({
                     userInput: "/duque",
-                    language: "narnian"
+                    language: "narnian",
                 });
                 assertEquals(ctx.getNearestCommand(cmds), "/duke");
             });
@@ -429,21 +429,21 @@ describe("Jaro-Wrinkler Algorithm", () => {
             it("ender", () => {
                 let ctx = dummyCtx({
                     userInput: "/endr",
-                    language: "es"
+                    language: "es",
                 });
                 assertEquals(ctx.getNearestCommand(cmds), "/ender");
             });
             it("endanger", () => {
                 let ctx = dummyCtx({
                     userInput: "/enanger",
-                    language: "en"
+                    language: "en",
                 });
                 assertEquals(ctx.getNearestCommand(cmds), "/endanger");
             });
             it("entitle", () => {
                 let ctx = dummyCtx({
                     userInput: "/entities",
-                    language: "pt"
+                    language: "pt",
                 });
                 assertEquals(ctx.getNearestCommand(cmds), "/entitle");
             });
@@ -451,32 +451,32 @@ describe("Jaro-Wrinkler Algorithm", () => {
     });
     describe("Test multiple commands instances", () => {
         const cmds = new Commands<Context>();
-        cmds.command("bread", "_", () => { })
+        cmds.command("bread", "_", () => {})
             .localize("es", "pan", "_")
             .localize("fr", "pain", "_");
 
         const cmds2 = new Commands<Context>();
 
-        cmds.command("dad", "_", () => { })
+        cmds.command("dad", "_", () => {})
             .localize("es", "papa", "_")
             .localize("fr", "pere", "_");
 
         it("Should get the nearest between multiple command classes", () => {
             let ctx = dummyCtx({
                 userInput: "/papi",
-                language: "es"
+                language: "es",
             });
             assertEquals(ctx.getNearestCommand([cmds, cmds2]), "/papa");
             ctx = dummyCtx({
                 userInput: "/pai",
-                language: "fr"
+                language: "fr",
             });
             assertEquals(ctx.getNearestCommand([cmds, cmds2]), "/pain");
         });
         it("Without localization it should get the best between multiple command classes", () => {
             let ctx = dummyCtx({
                 userInput: "/pana",
-                language: "???"
+                language: "???",
             });
             assertEquals(
                 ctx.getNearestCommand([cmds, cmds2], {
@@ -486,7 +486,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             );
             ctx = dummyCtx({
                 userInput: "/para",
-                language: "???"
+                language: "???",
             });
             assertEquals(
                 ctx.getNearestCommand([cmds, cmds2], {
@@ -497,4 +497,3 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
     });
 });
-

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -115,7 +115,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 .localize("es", "duque", "_")
                 .localize("fr", "duc", "_");
 
-            it("must output all commands names, language and prefix", () => {
+            it("should output all commands names, language and prefix", () => {
                 const json = cmds.toElementals();
                 assertArrayIncludes(json, [
                     { name: "butcher", language: "default", prefix: "?" },
@@ -127,7 +127,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 ]);
             });
         });
-        describe("Should return the command localization related to the user lang", () => {
+        describe("should return the command localization related to the user lang", () => {
             const cmds = new Commands<Context>();
             cmds.command("duke", "sniper", () => {})
                 .localize("es", "duque", "_")
@@ -217,7 +217,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
                     ));
             });
         });
-        describe("Should return the command localization related to the user lang for similar command names from different command classes", () => {
+        describe("should return the command localization related to the user lang for similar command names from different command classes", () => {
             const cmds = new Commands<Context>();
             cmds.command("push", "push", () => {})
                 .localize("fr", "pousser", "a")
@@ -298,7 +298,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
         cmds.command("endanger", "_", () => {});
         cmds.command("entitle", "_", () => {});
 
-        it("Should return null when no msg is given", () => {
+        it("should return null when no msg is given", () => {
             let ctx = dummyCtx({
                 userInput: "",
             });
@@ -308,7 +308,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             );
         });
 
-        describe("Should ignore localization when set to, and search trough all commands", () => {
+        describe("should ignore localization when set to, and search trough all commands", () => {
             it("ignore even if the language is set", () => { // should this console.warn? or maybe use an overload?
                 let ctx = dummyCtx({
                     userInput: "/duci",
@@ -461,7 +461,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             .localize("es", "papa", "_")
             .localize("fr", "pere", "_");
 
-        it("Should get the nearest between multiple command classes", () => {
+        it("should get the nearest between multiple command classes", () => {
             let ctx = dummyCtx({
                 userInput: "/papi",
                 language: "es",

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -297,16 +297,24 @@ describe("Jaro-Wrinkler Algorithm", () => {
         cmds.command("endanger", "_", () => {});
         cmds.command("entitle", "_", () => {});
 
+        it("Should return null when no msg is given", () => {
+            let ctx = dummyCtx("");
+            assertEquals(
+                ctx.getNearestCommand(cmds),
+                null,
+            );
+        });
+
         describe("Should ignore localization when set to, and search trough all commands", () => {
             it("ignore even if the language is set", () => { // should this console.warn? or maybe use an overload?
-                let ctx = dummyCtx("duci", "es");
+                let ctx = dummyCtx("/duci", "es");
                 assertEquals(
                     ctx.getNearestCommand(cmds, {
                         ignoreLocalization: true,
                     }),
                     "/duc",
                 );
-                ctx = dummyCtx("duki", "es");
+                ctx = dummyCtx("/duki", "es");
                 assertEquals(
                     ctx.getNearestCommand(cmds, {
                         ignoreLocalization: true,
@@ -315,48 +323,48 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 );
             });
             it("ignore when the language is not set", () => {
-                let ctx = dummyCtx("duki", "es");
+                let ctx = dummyCtx("/duki", "es");
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "/duke",
                 );
-                ctx = dummyCtx("macellaoo", "es");
+                ctx = dummyCtx("/macellaoo", "es");
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "+macellaio",
                 );
-                ctx = dummyCtx("dadd", "es");
+                ctx = dummyCtx("/dadd", "es");
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "?daddy",
                 );
-                ctx = dummyCtx("duk", "es");
+                ctx = dummyCtx("/duk", "es");
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "/duke",
                 );
             });
             it("should not restrict itself to default", () => {
-                let ctx = dummyCtx("duqu", "es");
+                let ctx = dummyCtx("/duqu", "es");
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "/duque",
                 );
             });
             it("language not know, but ignore localization still matches the best similarity", () => {
-                let ctx = dummyCtx("duqu", "en-papacito");
+                let ctx = dummyCtx("/duqu", "en-papacito");
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "/duque",
                 );
             });
             it("should chose localization if not ignore", () => {
-                let ctx = dummyCtx("duku", "es");
+                let ctx = dummyCtx("/duku", "es");
                 assertEquals(
                     ctx.getNearestCommand(cmds),
                     "/duque",
                 );
-                ctx = dummyCtx("duk", "fr");
+                ctx = dummyCtx("/duk", "fr");
                 assertEquals(
                     ctx.getNearestCommand(cmds),
                     "/duc",
@@ -365,27 +373,27 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
         describe("should not fail even if the language it's not know", () => {
             it("should fallback to default", () => {
-                let ctx = dummyCtx("duko", "en-papacito");
+                let ctx = dummyCtx("/duko", "en-papacito");
                 assertEquals(ctx.getNearestCommand(cmds), "/duke");
-                ctx = dummyCtx("butxher", "no-language");
+                ctx = dummyCtx("/butxher", "no-language");
                 assertEquals(ctx.getNearestCommand(cmds), "+butcher");
             });
             it("should not fallback to a locale even if its the same name", () => {
-                let ctx = dummyCtx("duque", "narnian");
+                let ctx = dummyCtx("/duque", "narnian");
                 assertEquals(ctx.getNearestCommand(cmds), "/duke");
             });
         });
         describe("should work for commands with no localization, even when the language is set", () => {
             it("ender", () => {
-                let ctx = dummyCtx("endr", "es");
+                let ctx = dummyCtx("/endr", "es");
                 assertEquals(ctx.getNearestCommand(cmds), "/ender");
             });
             it("endanger", () => {
-                let ctx = dummyCtx("enanger", "en");
+                let ctx = dummyCtx("/enanger", "en");
                 assertEquals(ctx.getNearestCommand(cmds), "/endanger");
             });
             it("entitle", () => {
-                let ctx = dummyCtx("entities", "pt");
+                let ctx = dummyCtx("/entities", "pt");
                 assertEquals(ctx.getNearestCommand(cmds), "/entitle");
             });
         });
@@ -403,20 +411,20 @@ describe("Jaro-Wrinkler Algorithm", () => {
             .localize("fr", "pere", "_");
 
         it("Should get the nearest between multiple command classes", () => {
-            let ctx = dummyCtx("papi", "es");
+            let ctx = dummyCtx("/papi", "es");
             assertEquals(ctx.getNearestCommand([cmds, cmds2]), "/papa");
-            ctx = dummyCtx("pai", "fr");
+            ctx = dummyCtx("/pai", "fr");
             assertEquals(ctx.getNearestCommand([cmds, cmds2]), "/pain");
         });
         it("Without localization it should get the best between multiple command classes", () => {
-            let ctx = dummyCtx("pana", "???");
+            let ctx = dummyCtx("/pana", "???");
             assertEquals(
                 ctx.getNearestCommand([cmds, cmds2], {
                     ignoreLocalization: true,
                 }),
                 "/pan",
             );
-            ctx = dummyCtx("para", "???");
+            ctx = dummyCtx("/para", "???");
             assertEquals(
                 ctx.getNearestCommand([cmds, cmds2], {
                     ignoreLocalization: true,
@@ -431,7 +439,7 @@ function dummyCtx(userCommandInput: string, language?: string) {
     const u = { id: 42, first_name: "yo", language_code: language } as User;
     const c = { id: 100, type: "private" } as Chat;
     const m = {
-        text: "/" + userCommandInput,
+        text: userCommandInput,
         from: u,
         chat: c,
     } as Message;

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -106,5 +106,43 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 assertEquals(json[1].name, "duque");
             });
         });
+        describe('Should return the command localization related to the user lang', () => {
+            const cmds = new Commands<Context>();
+            cmds.command('duke', 'sniper', () => { })
+                .localize('es', 'duque', '_')
+                .localize('fr', 'duc', '_')
+                .localize('it', 'duca', '_')
+                .localize('pt', 'duque', '_')
+                .localize('de', 'herzog', '_')
+                .localize('sv', 'hertig', '_')
+                .localize('da', 'hertug', '_')
+                .localize('fi', 'herttua', '_')
+                .localize('hu', 'herceg', '_')
+
+            it("sv", () => {
+                assertEquals(fuzzyMatch('hertog', cmds, {}), "hertig");
+            });
+            it("da", () => {
+                assertEquals(fuzzyMatch('hertog', cmds, {}), "hertug");
+            });
+            it("default", () => {
+                assertEquals(fuzzyMatch('duk', cmds, {}), "duke");
+                assertEquals(fuzzyMatch('duka', cmds, {}), "duke");
+                assertEquals(fuzzyMatch('duqa', cmds, {}), "duke");
+                assertEquals(fuzzyMatch('duqe', cmds, {}), "duke");
+            });
+            it("es", () => {
+                assertEquals(fuzzyMatch('duk', cmds, {}), "duque");
+                assertEquals(fuzzyMatch('duke', cmds, {}), "duque");
+                assertEquals(fuzzyMatch('dukue', cmds, {}), "duque");
+                assertEquals(fuzzyMatch('duqe', cmds, {}), "duque");
+            });
+            it("fr", () => {
+                assertEquals(fuzzyMatch('duk', cmds, {}), "duc");
+                assertEquals(fuzzyMatch('duco', cmds, {}), "duc");
+                assertEquals(fuzzyMatch('duca', cmds, {}), "duc");
+                assertEquals(fuzzyMatch('ducce', cmds, {}), "duc");
+            });
+        })
     });
 });

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -46,10 +46,10 @@ describe("Jaro-Wrinkler Algorithm", () => {
             cmds.command(
                 "start",
                 "Starting",
-                () => { },
+                () => {},
             );
             assertEquals(
-                fuzzyMatch("strt", cmds, { language: "fr" })?.name,
+                fuzzyMatch("strt", cmds, { language: "fr" })?.command?.name,
                 "start",
             );
         });
@@ -60,7 +60,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             cmds.command(
                 "start",
                 "Starting",
-                () => { },
+                () => {},
             ).addToScope(
                 { type: "all_private_chats" },
                 (ctx) => ctx.reply(`Hello, ${ctx.chat.first_name}!`),
@@ -79,7 +79,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 (ctx) => ctx.reply(`Hello, ${ctx.chat.first_name}!`),
             );
             assertEquals(
-                fuzzyMatch("magcal", cmds, { language: "fr" })?.name,
+                fuzzyMatch("magcal", cmds, { language: "fr" })?.command?.name,
                 "magical_\\d",
             );
         });
@@ -94,11 +94,11 @@ describe("Jaro-Wrinkler Algorithm", () => {
             ).localize("es", /magico_(c|d)/, "Comando Mágico");
 
             assertEquals(
-                fuzzyMatch("magici_c", cmds, { language: "es" })?.name,
+                fuzzyMatch("magici_c", cmds, { language: "es" })?.command?.name,
                 "magico_(c|d)",
             );
             assertEquals(
-                fuzzyMatch("magici_a", cmds, { language: "fr" })?.name,
+                fuzzyMatch("magici_a", cmds, { language: "fr" })?.command?.name,
                 "magical_(a|b)",
             );
         });
@@ -106,16 +106,16 @@ describe("Jaro-Wrinkler Algorithm", () => {
     describe("Serialize commands for FuzzyMatch", () => {
         describe("toNameAndPrefix", () => {
             const cmds = new Commands<Context>();
-            cmds.command("butcher", "_", () => { }, { prefix: "?" })
+            cmds.command("butcher", "_", () => {}, { prefix: "?" })
                 .localize("es", "carnicero", "_")
                 .localize("it", "macellaio", "_");
 
-            cmds.command("duke", "_", () => { })
+            cmds.command("duke", "_", () => {})
                 .localize("es", "duque", "_")
                 .localize("fr", "duc", "_");
 
             it("must output all commands names, language and prefix", () => {
-                const json = cmds.toNameAndPrefix();
+                const json = cmds.toElementals();
                 assertArrayIncludes(json, [
                     { name: "butcher", language: "default", prefix: "?" },
                     { name: "carnicero", language: "es", prefix: "?" },
@@ -128,7 +128,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
         describe("Should return the command localization related to the user lang", () => {
             const cmds = new Commands<Context>();
-            cmds.command("duke", "sniper", () => { })
+            cmds.command("duke", "sniper", () => {})
                 .localize("es", "duque", "_")
                 .localize("fr", "duc", "_")
                 .localize("it", "duca", "_")
@@ -141,112 +141,140 @@ describe("Jaro-Wrinkler Algorithm", () => {
 
             it("sv", () => {
                 assertEquals(
-                    fuzzyMatch("hertog", cmds, { language: "sv" })?.name,
+                    fuzzyMatch("hertog", cmds, { language: "sv" })?.command
+                        ?.name,
                     "hertig",
                 );
             });
             it("da", () => {
                 assertEquals(
-                    fuzzyMatch("hertog", cmds, { language: "da" })?.name,
+                    fuzzyMatch("hertog", cmds, { language: "da" })?.command
+                        ?.name,
                     "hertug",
                 );
             });
             describe("default", () => {
                 it("duke", () =>
-                    assertEquals(fuzzyMatch("duk", cmds, {})?.name, "duke"));
+                    assertEquals(
+                        fuzzyMatch("duk", cmds, {})?.command?.name,
+                        "duke",
+                    ));
                 it("duke", () =>
-                    assertEquals(fuzzyMatch("due", cmds, {})?.name, "duke"));
+                    assertEquals(
+                        fuzzyMatch("due", cmds, {})?.command?.name,
+                        "duke",
+                    ));
                 it("duke", () =>
-                    assertEquals(fuzzyMatch("dule", cmds, {})?.name, "duke"));
+                    assertEquals(
+                        fuzzyMatch("dule", cmds, {})?.command?.name,
+                        "duke",
+                    ));
                 it("duke", () =>
-                    assertEquals(fuzzyMatch("duje", cmds, {})?.name, "duke"));
+                    assertEquals(
+                        fuzzyMatch("duje", cmds, {})?.command?.name,
+                        "duke",
+                    ));
             });
             describe("es", () => {
                 it("duque", () =>
                     assertEquals(
-                        fuzzyMatch("duquw", cmds, { language: "es" })?.name,
+                        fuzzyMatch("duquw", cmds, { language: "es" })?.command
+                            ?.name,
                         "duque",
                     ));
                 it("duque", () =>
                     assertEquals(
-                        fuzzyMatch("duqe", cmds, { language: "es" })?.name,
+                        fuzzyMatch("duqe", cmds, { language: "es" })?.command
+                            ?.name,
                         "duque",
                     ));
                 it("duque", () =>
                     assertEquals(
-                        fuzzyMatch("duwue", cmds, { language: "es" })?.name,
+                        fuzzyMatch("duwue", cmds, { language: "es" })?.command
+                            ?.name,
                         "duque",
                     ));
             });
             describe("fr", () => {
                 it("duc", () =>
                     assertEquals(
-                        fuzzyMatch("duk", cmds, { language: "fr" })?.name,
+                        fuzzyMatch("duk", cmds, { language: "fr" })?.command
+                            ?.name,
                         "duc",
                     ));
                 it("duc", () =>
                     assertEquals(
-                        fuzzyMatch("duce", cmds, { language: "fr" })?.name,
+                        fuzzyMatch("duce", cmds, { language: "fr" })?.command
+                            ?.name,
                         "duc",
                     ));
                 it("duc", () =>
                     assertEquals(
-                        fuzzyMatch("ducñ", cmds, { language: "fr" })?.name,
+                        fuzzyMatch("ducñ", cmds, { language: "fr" })?.command
+                            ?.name,
                         "duc",
                     ));
             });
         });
         describe("Should return the command localization related to the user lang for similar command names from different command classes", () => {
             const cmds = new Commands<Context>();
-            cmds.command("push", "push", () => { })
+            cmds.command("push", "push", () => {})
                 .localize("fr", "pousser", "a")
                 .localize("pt", "empurrar", "b");
 
-            cmds.command("rest", "rest", () => { })
+            cmds.command("rest", "rest", () => {})
                 .localize("fr", "reposer", "c")
                 .localize("pt", "poussar", "d");
 
             describe("pt rest", () => {
                 it("poussar", () =>
                     assertEquals(
-                        fuzzyMatch("pousssr", cmds, { language: "pt" })?.name,
+                        fuzzyMatch("pousssr", cmds, { language: "pt" })?.command
+                            ?.name,
                         "poussar",
                     ));
                 it("poussar", () =>
                     assertEquals(
-                        fuzzyMatch("pousar", cmds, { language: "pt" })?.name,
+                        fuzzyMatch("pousar", cmds, { language: "pt" })?.command
+                            ?.name,
                         "poussar",
                     ));
                 it("poussar", () =>
                     assertEquals(
-                        fuzzyMatch("poussqr", cmds, { language: "pt" })?.name,
+                        fuzzyMatch("poussqr", cmds, { language: "pt" })?.command
+                            ?.name,
                         "poussar",
                     ));
                 it("poussar", () =>
                     assertEquals(
-                        fuzzyMatch("poussrr", cmds, { language: "pt" })?.name,
+                        fuzzyMatch("poussrr", cmds, { language: "pt" })?.command
+                            ?.name,
                         "poussar",
                     ));
             });
             describe("fr push", () => {
                 it("pousser", () =>
                     assertEquals(
-                        fuzzyMatch("pousssr", cmds, { language: "fr" })?.name,
+                        fuzzyMatch("pousssr", cmds, { language: "fr" })?.command
+                            ?.name,
                         "pousser",
                     ));
                 it("pousser", () =>
                     assertEquals(
-                        fuzzyMatch("pouser", cmds, { language: "fr" })?.name,
+                        fuzzyMatch("pouser", cmds, { language: "fr" })?.command
+                            ?.name,
                         "pousser",
                     ));
                 it("pousser", () =>
                     assertEquals(
-                        fuzzyMatch("pousrr", cmds, { language: "fr" })?.name,
+                        fuzzyMatch("pousrr", cmds, { language: "fr" })?.command
+                            ?.name,
                         "pousser",
                     ));
                 it("pousser", () =>
                     assertEquals(
-                        fuzzyMatch("poussrr", cmds, { language: "fr" })?.name,
+                        fuzzyMatch("poussrr", cmds, { language: "fr" })?.command
+                            ?.name,
                         "pousser",
                     ));
             });
@@ -254,20 +282,20 @@ describe("Jaro-Wrinkler Algorithm", () => {
     });
     describe("Usage inside ctx", () => {
         const cmds = new Commands<Context>();
-        cmds.command("butcher", "_", () => { }, { prefix: "+" })
+        cmds.command("butcher", "_", () => {}, { prefix: "+" })
             .localize("es", "carnicero", "_")
             .localize("it", "macellaio", "_");
 
-        cmds.command("duke", "_", () => { })
+        cmds.command("duke", "_", () => {})
             .localize("es", "duque", "_")
             .localize("fr", "duc", "_");
 
-        cmds.command("daddy", "me", () => { }, { prefix: "?" })
+        cmds.command("daddy", "me", () => {}, { prefix: "?" })
             .localize("es", "papito", "yeyo");
 
-        cmds.command('ender','_', () => {})
-        cmds.command('endanger','_', () => {})
-        cmds.command('entitle','_', () => {})
+        cmds.command("ender", "_", () => {});
+        cmds.command("endanger", "_", () => {});
+        cmds.command("entitle", "_", () => {});
 
         describe("Should ignore localization when set to, and search trough all commands", () => {
             it("ignore even if the language is set", () => { // should this console.warn? or maybe use an overload?
@@ -349,7 +377,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
         describe("should work for commands with no localization, even when the language is set", () => {
             it("ender", () => {
-                let ctx = dummyCtx("endr", 'es');
+                let ctx = dummyCtx("endr", "es");
                 assertEquals(ctx.getNearestCommand(cmds), "/ender");
             });
             it("endanger", () => {
@@ -360,6 +388,41 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 let ctx = dummyCtx("entities", "pt");
                 assertEquals(ctx.getNearestCommand(cmds), "/entitle");
             });
+        });
+    });
+    describe("Test multiple commands instances", () => {
+        const cmds = new Commands<Context>();
+        cmds.command("bread", "_", () => {})
+            .localize("es", "pan", "_")
+            .localize("fr", "pain", "_");
+
+        const cmds2 = new Commands<Context>();
+
+        cmds.command("dad", "_", () => {})
+            .localize("es", "papa", "_")
+            .localize("fr", "pere", "_");
+
+        it("Should get the nearest between multiple command classes", () => {
+            let ctx = dummyCtx("papi", "es");
+            assertEquals(ctx.getNearestCommand([cmds, cmds2]), "/papa");
+            ctx = dummyCtx("pai", "fr");
+            assertEquals(ctx.getNearestCommand([cmds, cmds2]), "/pain");
+        });
+        it("Without localization it should get the best between multiple command classes", () => {
+            let ctx = dummyCtx("pana", "???");
+            assertEquals(
+                ctx.getNearestCommand([cmds, cmds2], {
+                    ignoreLocalization: true,
+                }),
+                "/pan",
+            );
+            ctx = dummyCtx("para", "???");
+            assertEquals(
+                ctx.getNearestCommand([cmds, cmds2], {
+                    ignoreLocalization: true,
+                }),
+                "/papa",
+            );
         });
     });
 });
@@ -379,6 +442,6 @@ function dummyCtx(userCommandInput: string, language?: string) {
     const me = { id: 42, username: "bot" } as UserFromGetMe;
     const ctx = new Context(update, api, me) as CommandsFlavor<Context>;
     const middleware = commands();
-    middleware(ctx, async () => { });
+    middleware(ctx, async () => {});
     return ctx;
 }

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -38,7 +38,10 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 (ctx) => ctx.reply(`Hello, ${ctx.chat.first_name}!`),
             );
 
-            assertEquals(fuzzyMatch("strt", cmds, {})?.name, "start");
+            assertEquals(
+                fuzzyMatch("strt", cmds, { language: "fr" })?.name,
+                "start",
+            );
         });
 
         it("should return null because command doesn't exist", () => {
@@ -64,7 +67,10 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 { type: "all_private_chats" },
                 (ctx) => ctx.reply(`Hello, ${ctx.chat.first_name}!`),
             );
-            assertEquals(fuzzyMatch("magcal", cmds, {})?.name, "magical_\\d");
+            assertEquals(
+                fuzzyMatch("magcal", cmds, { language: "fr" })?.name,
+                "magical_\\d",
+            );
         });
         it("should work for localized regex", () => {
             const cmds = new Commands<Context>();
@@ -77,11 +83,11 @@ describe("Jaro-Wrinkler Algorithm", () => {
             ).localize("es", /magico_(c|d)/, "Comando Mágico");
 
             assertEquals(
-                fuzzyMatch("magici_c", cmds, {language: 'es'})?.name,
+                fuzzyMatch("magici_c", cmds, { language: "es" })?.name,
                 "magico_(c|d)",
             );
             assertEquals(
-                fuzzyMatch("magici_a", cmds, {})?.name,
+                fuzzyMatch("magici_a", cmds, { language: "fr" })?.name,
                 "magical_(a|b)",
             );
         });
@@ -120,67 +126,115 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 .localize("hu", "herceg", "_");
 
             it("sv", () => {
-                assertEquals(fuzzyMatch("hertog", cmds, {}), "hertig");
+                assertEquals(
+                    fuzzyMatch("hertog", cmds, { language: "sv" })?.name,
+                    "hertig",
+                );
             });
             it("da", () => {
-                assertEquals(fuzzyMatch("hertog", cmds, {}), "hertug");
+                assertEquals(
+                    fuzzyMatch("hertog", cmds, { language: "da" })?.name,
+                    "hertug",
+                );
             });
             describe("default", () => {
                 it("duke", () =>
-                    assertEquals(fuzzyMatch("duk", cmds, {}), "duke"));
+                    assertEquals(fuzzyMatch("duk", cmds, {})?.name, "duke"));
                 it("duke", () =>
-                    assertEquals(fuzzyMatch("due", cmds, {}), "duke"));
+                    assertEquals(fuzzyMatch("due", cmds, {})?.name, "duke"));
                 it("duke", () =>
-                    assertEquals(fuzzyMatch("dule", cmds, {}), "duke"));
+                    assertEquals(fuzzyMatch("dule", cmds, {})?.name, "duke"));
                 it("duke", () =>
-                    assertEquals(fuzzyMatch("duje", cmds, {}), "duke"));
+                    assertEquals(fuzzyMatch("duje", cmds, {})?.name, "duke"));
             });
             describe("es", () => {
                 it("duque", () =>
-                    assertEquals(fuzzyMatch("duquw", cmds, {}), "duque"));
+                    assertEquals(
+                        fuzzyMatch("duquw", cmds, { language: "es" })?.name,
+                        "duque",
+                    ));
                 it("duque", () =>
-                    assertEquals(fuzzyMatch("duqe", cmds, {}), "duque"));
+                    assertEquals(
+                        fuzzyMatch("duqe", cmds, { language: "es" })?.name,
+                        "duque",
+                    ));
                 it("duque", () =>
-                    assertEquals(fuzzyMatch("duwue", cmds, {}), "duque"));
+                    assertEquals(
+                        fuzzyMatch("duwue", cmds, { language: "es" })?.name,
+                        "duque",
+                    ));
             });
             describe("fr", () => {
                 it("duc", () =>
-                    assertEquals(fuzzyMatch("duk", cmds, {}), "duc"));
+                    assertEquals(
+                        fuzzyMatch("duk", cmds, { language: "fr" })?.name,
+                        "duc",
+                    ));
                 it("duc", () =>
-                    assertEquals(fuzzyMatch("duce", cmds, {}), "duc"));
+                    assertEquals(
+                        fuzzyMatch("duce", cmds, { language: "fr" })?.name,
+                        "duc",
+                    ));
                 it("duc", () =>
-                    assertEquals(fuzzyMatch("ducñ", cmds, {}), "duc"));
+                    assertEquals(
+                        fuzzyMatch("ducñ", cmds, { language: "fr" })?.name,
+                        "duc",
+                    ));
             });
         });
         describe("Should return the command localization related to the user lang for similar command names from different command classes", () => {
             const cmds = new Commands<Context>();
             cmds.command("push", "push", () => {})
-                .localize("fr", "pousser", "_")
-                .localize("pt", "empurrar", "_");
+                .localize("fr", "pousser", "a")
+                .localize("pt", "empurrar", "b");
 
-            cmds.command("rest", "rest")
-                .localize("fr", "reposer", "_")
-                .localize("pt", "poussar", "_");
+            cmds.command("rest", "rest", () => {})
+                .localize("fr", "reposer", "c")
+                .localize("pt", "poussar", "d");
 
             describe("pt rest", () => {
                 it("poussar", () =>
-                    assertEquals(fuzzyMatch("pousssr", cmds, {}), "poussar"));
+                    assertEquals(
+                        fuzzyMatch("pousssr", cmds, { language: "pt" })?.name,
+                        "poussar",
+                    ));
                 it("poussar", () =>
-                    assertEquals(fuzzyMatch("pousar", cmds, {}), "poussar"));
+                    assertEquals(
+                        fuzzyMatch("pousar", cmds, { language: "pt" })?.name,
+                        "poussar",
+                    ));
                 it("poussar", () =>
-                    assertEquals(fuzzyMatch("poussqr", cmds, {}), "poussar"));
+                    assertEquals(
+                        fuzzyMatch("poussqr", cmds, { language: "pt" })?.name,
+                        "poussar",
+                    ));
                 it("poussar", () =>
-                    assertEquals(fuzzyMatch("poussrr", cmds, {}), "poussar"));
+                    assertEquals(
+                        fuzzyMatch("poussrr", cmds, { language: "pt" })?.name,
+                        "poussar",
+                    ));
             });
             describe("fr push", () => {
-                it("poussar", () =>
-                    assertEquals(fuzzyMatch("pousssr", cmds, {}), "pousser"));
-                it("poussar", () =>
-                    assertEquals(fuzzyMatch("pouser", cmds, {}), "pousser"));
-                it("poussar", () =>
-                    assertEquals(fuzzyMatch("pousrr", cmds, {}), "pousser"));
-                it("poussar", () =>
-                    assertEquals(fuzzyMatch("poussrr", cmds, {}), "pousser"));
+                it("pousser", () =>
+                    assertEquals(
+                        fuzzyMatch("pousssr", cmds, { language: "fr" })?.name,
+                        "pousser",
+                    ));
+                it("pousser", () =>
+                    assertEquals(
+                        fuzzyMatch("pouser", cmds, { language: "fr" })?.name,
+                        "pousser",
+                    ));
+                it("pousser", () =>
+                    assertEquals(
+                        fuzzyMatch("pousrr", cmds, { language: "fr" })?.name,
+                        "pousser",
+                    ));
+                it("pousser", () =>
+                    assertEquals(
+                        fuzzyMatch("poussrr", cmds, { language: "fr" })?.name,
+                        "pousser",
+                    ));
             });
         });
     });

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -18,6 +18,7 @@ import {
     User,
     UserFromGetMe,
 } from "./deps.test.ts";
+import { dummyCtx } from "./context.test.ts";
 
 describe("Jaro-Wrinkler Algorithm", () => {
     it("should return value 0, because the empty string was given", () => {
@@ -46,7 +47,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             cmds.command(
                 "start",
                 "Starting",
-                () => {},
+                () => { },
             );
             assertEquals(
                 fuzzyMatch("strt", cmds, { language: "fr" })?.command?.name,
@@ -60,7 +61,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             cmds.command(
                 "start",
                 "Starting",
-                () => {},
+                () => { },
             ).addToScope(
                 { type: "all_private_chats" },
                 (ctx) => ctx.reply(`Hello, ${ctx.chat.first_name}!`),
@@ -106,11 +107,11 @@ describe("Jaro-Wrinkler Algorithm", () => {
     describe("Serialize commands for FuzzyMatch", () => {
         describe("toNameAndPrefix", () => {
             const cmds = new Commands<Context>();
-            cmds.command("butcher", "_", () => {}, { prefix: "?" })
+            cmds.command("butcher", "_", () => { }, { prefix: "?" })
                 .localize("es", "carnicero", "_")
                 .localize("it", "macellaio", "_");
 
-            cmds.command("duke", "_", () => {})
+            cmds.command("duke", "_", () => { })
                 .localize("es", "duque", "_")
                 .localize("fr", "duc", "_");
 
@@ -128,7 +129,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
         describe("Should return the command localization related to the user lang", () => {
             const cmds = new Commands<Context>();
-            cmds.command("duke", "sniper", () => {})
+            cmds.command("duke", "sniper", () => { })
                 .localize("es", "duque", "_")
                 .localize("fr", "duc", "_")
                 .localize("it", "duca", "_")
@@ -218,11 +219,11 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
         describe("Should return the command localization related to the user lang for similar command names from different command classes", () => {
             const cmds = new Commands<Context>();
-            cmds.command("push", "push", () => {})
+            cmds.command("push", "push", () => { })
                 .localize("fr", "pousser", "a")
                 .localize("pt", "empurrar", "b");
 
-            cmds.command("rest", "rest", () => {})
+            cmds.command("rest", "rest", () => { })
                 .localize("fr", "reposer", "c")
                 .localize("pt", "poussar", "d");
 
@@ -282,23 +283,25 @@ describe("Jaro-Wrinkler Algorithm", () => {
     });
     describe("Usage inside ctx", () => {
         const cmds = new Commands<Context>();
-        cmds.command("butcher", "_", () => {}, { prefix: "+" })
+        cmds.command("butcher", "_", () => { }, { prefix: "+" })
             .localize("es", "carnicero", "_")
             .localize("it", "macellaio", "_");
 
-        cmds.command("duke", "_", () => {})
+        cmds.command("duke", "_", () => { })
             .localize("es", "duque", "_")
             .localize("fr", "duc", "_");
 
-        cmds.command("daddy", "me", () => {}, { prefix: "?" })
+        cmds.command("daddy", "me", () => { }, { prefix: "?" })
             .localize("es", "papito", "yeyo");
 
-        cmds.command("ender", "_", () => {});
-        cmds.command("endanger", "_", () => {});
-        cmds.command("entitle", "_", () => {});
+        cmds.command("ender", "_", () => { });
+        cmds.command("endanger", "_", () => { });
+        cmds.command("entitle", "_", () => { });
 
         it("Should return null when no msg is given", () => {
-            let ctx = dummyCtx("");
+            let ctx = dummyCtx({
+                userInput: ""
+            });
             assertEquals(
                 ctx.getNearestCommand(cmds),
                 null,
@@ -307,14 +310,20 @@ describe("Jaro-Wrinkler Algorithm", () => {
 
         describe("Should ignore localization when set to, and search trough all commands", () => {
             it("ignore even if the language is set", () => { // should this console.warn? or maybe use an overload?
-                let ctx = dummyCtx("/duci", "es");
+                let ctx = dummyCtx({
+                    userInput: "/duci",
+                    language: "es"
+                });
                 assertEquals(
                     ctx.getNearestCommand(cmds, {
                         ignoreLocalization: true,
                     }),
                     "/duc",
                 );
-                ctx = dummyCtx("/duki", "es");
+                ctx = dummyCtx({
+                    userInput: "/duki",
+                    language: "es"
+                });
                 assertEquals(
                     ctx.getNearestCommand(cmds, {
                         ignoreLocalization: true,
@@ -323,48 +332,72 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 );
             });
             it("ignore when the language is not set", () => {
-                let ctx = dummyCtx("/duki", "es");
+                let ctx = dummyCtx({
+                    userInput: "/duki",
+                    language: "es"
+                });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "/duke",
                 );
-                ctx = dummyCtx("/macellaoo", "es");
+                ctx = dummyCtx({
+                    userInput: "/macellaoo",
+                    language: "es"
+                });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "+macellaio",
                 );
-                ctx = dummyCtx("/dadd", "es");
+                ctx = dummyCtx({
+                    userInput: "/dadd",
+                    language: "es"
+                });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "?daddy",
                 );
-                ctx = dummyCtx("/duk", "es");
+                ctx = dummyCtx({
+                    userInput: "/duk",
+                    language: "es"
+                });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "/duke",
                 );
             });
             it("should not restrict itself to default", () => {
-                let ctx = dummyCtx("/duqu", "es");
+                let ctx = dummyCtx({
+                    userInput: "/duqu",
+                    language: "es"
+                });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "/duque",
                 );
             });
             it("language not know, but ignore localization still matches the best similarity", () => {
-                let ctx = dummyCtx("/duqu", "en-papacito");
+                let ctx = dummyCtx({
+                    userInput: "/duqu",
+                    language: "en-papacito"
+                });
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "/duque",
                 );
             });
             it("should chose localization if not ignore", () => {
-                let ctx = dummyCtx("/duku", "es");
+                let ctx = dummyCtx({
+                    userInput: "/duku",
+                    language: "es"
+                });
                 assertEquals(
                     ctx.getNearestCommand(cmds),
                     "/duque",
                 );
-                ctx = dummyCtx("/duk", "fr");
+                ctx = dummyCtx({
+                    userInput: "/duk",
+                    language: "fr"
+                });
                 assertEquals(
                     ctx.getNearestCommand(cmds),
                     "/duc",
@@ -373,58 +406,88 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
         describe("should not fail even if the language it's not know", () => {
             it("should fallback to default", () => {
-                let ctx = dummyCtx("/duko", "en-papacito");
+                let ctx = dummyCtx({
+                    userInput: "/duko",
+                    language: "en-papacito"
+                });
                 assertEquals(ctx.getNearestCommand(cmds), "/duke");
-                ctx = dummyCtx("/butxher", "no-language");
+                ctx = dummyCtx({
+                    userInput: "/butxher",
+                    language: "no-language"
+                });
                 assertEquals(ctx.getNearestCommand(cmds), "+butcher");
             });
             it("should not fallback to a locale even if its the same name", () => {
-                let ctx = dummyCtx("/duque", "narnian");
+                let ctx = dummyCtx({
+                    userInput: "/duque",
+                    language: "narnian"
+                });
                 assertEquals(ctx.getNearestCommand(cmds), "/duke");
             });
         });
         describe("should work for commands with no localization, even when the language is set", () => {
             it("ender", () => {
-                let ctx = dummyCtx("/endr", "es");
+                let ctx = dummyCtx({
+                    userInput: "/endr",
+                    language: "es"
+                });
                 assertEquals(ctx.getNearestCommand(cmds), "/ender");
             });
             it("endanger", () => {
-                let ctx = dummyCtx("/enanger", "en");
+                let ctx = dummyCtx({
+                    userInput: "/enanger",
+                    language: "en"
+                });
                 assertEquals(ctx.getNearestCommand(cmds), "/endanger");
             });
             it("entitle", () => {
-                let ctx = dummyCtx("/entities", "pt");
+                let ctx = dummyCtx({
+                    userInput: "/entities",
+                    language: "pt"
+                });
                 assertEquals(ctx.getNearestCommand(cmds), "/entitle");
             });
         });
     });
     describe("Test multiple commands instances", () => {
         const cmds = new Commands<Context>();
-        cmds.command("bread", "_", () => {})
+        cmds.command("bread", "_", () => { })
             .localize("es", "pan", "_")
             .localize("fr", "pain", "_");
 
         const cmds2 = new Commands<Context>();
 
-        cmds.command("dad", "_", () => {})
+        cmds.command("dad", "_", () => { })
             .localize("es", "papa", "_")
             .localize("fr", "pere", "_");
 
         it("Should get the nearest between multiple command classes", () => {
-            let ctx = dummyCtx("/papi", "es");
+            let ctx = dummyCtx({
+                userInput: "/papi",
+                language: "es"
+            });
             assertEquals(ctx.getNearestCommand([cmds, cmds2]), "/papa");
-            ctx = dummyCtx("/pai", "fr");
+            ctx = dummyCtx({
+                userInput: "/pai",
+                language: "fr"
+            });
             assertEquals(ctx.getNearestCommand([cmds, cmds2]), "/pain");
         });
         it("Without localization it should get the best between multiple command classes", () => {
-            let ctx = dummyCtx("/pana", "???");
+            let ctx = dummyCtx({
+                userInput: "/pana",
+                language: "???"
+            });
             assertEquals(
                 ctx.getNearestCommand([cmds, cmds2], {
                     ignoreLocalization: true,
                 }),
                 "/pan",
             );
-            ctx = dummyCtx("/para", "???");
+            ctx = dummyCtx({
+                userInput: "/para",
+                language: "???"
+            });
             assertEquals(
                 ctx.getNearestCommand([cmds, cmds2], {
                     ignoreLocalization: true,
@@ -435,21 +498,3 @@ describe("Jaro-Wrinkler Algorithm", () => {
     });
 });
 
-function dummyCtx(userCommandInput: string, language?: string) {
-    const u = { id: 42, first_name: "yo", language_code: language } as User;
-    const c = { id: 100, type: "private" } as Chat;
-    const m = {
-        text: userCommandInput,
-        from: u,
-        chat: c,
-    } as Message;
-    const update = {
-        message: m,
-    } as Update;
-    const api = new Api("dummy-token");
-    const me = { id: 42, username: "bot" } as UserFromGetMe;
-    const ctx = new Context(update, api, me) as CommandsFlavor<Context>;
-    const middleware = commands();
-    middleware(ctx, async () => {});
-    return ctx;
-}

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -417,13 +417,6 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 });
                 assertEquals(ctx.getNearestCommand(cmds), "+butcher");
             });
-            it("should not fallback to a locale even if its the same name", () => {
-                let ctx = dummyCtx({
-                    userInput: "/duque",
-                    language: "narnian",
-                });
-                assertEquals(ctx.getNearestCommand(cmds), "/duke");
-            });
         });
         describe("should work for commands with no localization, even when the language is set", () => {
             it("ender", () => {
@@ -457,7 +450,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
 
         const cmds2 = new Commands<Context>();
 
-        cmds.command("dad", "_", () => {})
+        cmds2.command("dad", "_", () => {})
             .localize("es", "papa", "_")
             .localize("fr", "pere", "_");
 

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -46,7 +46,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             cmds.command(
                 "start",
                 "Starting",
-                () => {},
+                () => { },
             );
             assertEquals(
                 fuzzyMatch("strt", cmds, { language: "fr" })?.name,
@@ -60,7 +60,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             cmds.command(
                 "start",
                 "Starting",
-                () => {},
+                () => { },
             ).addToScope(
                 { type: "all_private_chats" },
                 (ctx) => ctx.reply(`Hello, ${ctx.chat.first_name}!`),
@@ -106,11 +106,11 @@ describe("Jaro-Wrinkler Algorithm", () => {
     describe("Serialize commands for FuzzyMatch", () => {
         describe("toNameAndPrefix", () => {
             const cmds = new Commands<Context>();
-            cmds.command("butcher", "_", () => {}, { prefix: "?" })
+            cmds.command("butcher", "_", () => { }, { prefix: "?" })
                 .localize("es", "carnicero", "_")
                 .localize("it", "macellaio", "_");
 
-            cmds.command("duke", "_", () => {})
+            cmds.command("duke", "_", () => { })
                 .localize("es", "duque", "_")
                 .localize("fr", "duc", "_");
 
@@ -128,7 +128,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
         describe("Should return the command localization related to the user lang", () => {
             const cmds = new Commands<Context>();
-            cmds.command("duke", "sniper", () => {})
+            cmds.command("duke", "sniper", () => { })
                 .localize("es", "duque", "_")
                 .localize("fr", "duc", "_")
                 .localize("it", "duca", "_")
@@ -198,11 +198,11 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
         describe("Should return the command localization related to the user lang for similar command names from different command classes", () => {
             const cmds = new Commands<Context>();
-            cmds.command("push", "push", () => {})
+            cmds.command("push", "push", () => { })
                 .localize("fr", "pousser", "a")
                 .localize("pt", "empurrar", "b");
 
-            cmds.command("rest", "rest", () => {})
+            cmds.command("rest", "rest", () => { })
                 .localize("fr", "reposer", "c")
                 .localize("pt", "poussar", "d");
 
@@ -254,15 +254,15 @@ describe("Jaro-Wrinkler Algorithm", () => {
     });
     describe("Usage inside ctx", () => {
         const cmds = new Commands<Context>();
-        cmds.command("butcher", "_", () => {}, { prefix: "+" })
+        cmds.command("butcher", "_", () => { }, { prefix: "+" })
             .localize("es", "carnicero", "_")
             .localize("it", "macellaio", "_");
 
-        cmds.command("duke", "_", () => {})
+        cmds.command("duke", "_", () => { })
             .localize("es", "duque", "_")
             .localize("fr", "duc", "_");
 
-        cmds.command("daddy", "me", () => {}, { prefix: "?" })
+        cmds.command("daddy", "me", () => { }, { prefix: "?" })
             .localize("es", "papito", "yeyo");
 
         describe("Should ignore localization when set to, and search trough all commands", () => {
@@ -271,7 +271,6 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 assertEquals(
                     ctx.getNearestCommand(cmds, {
                         ignoreLocalization: true,
-                        language: ctx.from?.language_code,
                     }),
                     "/duc",
                 );
@@ -279,7 +278,6 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 assertEquals(
                     ctx.getNearestCommand(cmds, {
                         ignoreLocalization: true,
-                        language: ctx.from?.language_code,
                     }),
                     "/duke",
                 );
@@ -300,6 +298,11 @@ describe("Jaro-Wrinkler Algorithm", () => {
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "?daddy",
                 );
+                ctx = dummyCtx("duk", "es");
+                assertEquals(
+                    ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
+                    "/duke",
+                );
             });
             it("should not restrict itself to default", () => {
                 let ctx = dummyCtx("duqu", "es");
@@ -313,6 +316,18 @@ describe("Jaro-Wrinkler Algorithm", () => {
                 assertEquals(
                     ctx.getNearestCommand(cmds, { ignoreLocalization: true }),
                     "/duque",
+                );
+            });
+            it("should chose localization if not ignore", () => {
+                let ctx = dummyCtx("duku", "es");
+                assertEquals(
+                    ctx.getNearestCommand(cmds),
+                    "/duque",
+                );
+                ctx = dummyCtx("duk", "fr");
+                assertEquals(
+                    ctx.getNearestCommand(cmds),
+                    "/duc",
                 );
             });
         });
@@ -346,6 +361,6 @@ function dummyCtx(userCommandInput: string, language?: string) {
     const me = { id: 42, username: "bot" } as UserFromGetMe;
     const ctx = new Context(update, api, me) as CommandsFlavor<Context>;
     const middleware = commands();
-    middleware(ctx, async () => {});
+    middleware(ctx, async () => { });
     return ctx;
 }

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -265,6 +265,10 @@ describe("Jaro-Wrinkler Algorithm", () => {
         cmds.command("daddy", "me", () => { }, { prefix: "?" })
             .localize("es", "papito", "yeyo");
 
+        cmds.command('ender','_', () => {})
+        cmds.command('endanger','_', () => {})
+        cmds.command('entitle','_', () => {})
+
         describe("Should ignore localization when set to, and search trough all commands", () => {
             it("ignore even if the language is set", () => { // should this console.warn? or maybe use an overload?
                 let ctx = dummyCtx("duci", "es");
@@ -341,6 +345,20 @@ describe("Jaro-Wrinkler Algorithm", () => {
             it("should not fallback to a locale even if its the same name", () => {
                 let ctx = dummyCtx("duque", "narnian");
                 assertEquals(ctx.getNearestCommand(cmds), "/duke");
+            });
+        });
+        describe("should work for commands with no localization, even when the language is set", () => {
+            it("ender", () => {
+                let ctx = dummyCtx("endr", 'es');
+                assertEquals(ctx.getNearestCommand(cmds), "/ender");
+            });
+            it("endanger", () => {
+                let ctx = dummyCtx("enanger", "en");
+                assertEquals(ctx.getNearestCommand(cmds), "/endanger");
+            });
+            it("entitle", () => {
+                let ctx = dummyCtx("entities", "pt");
+                assertEquals(ctx.getNearestCommand(cmds), "/entitle");
             });
         });
     });


### PR DESCRIPTION
- closes #18 
- closes #16 
- encapsulate return value for getNearestCommands to prefix+name

Pending:
- [x] Runtime check for `ctx.from.language_code` (IETF > iso-639), would benefit from https://github.com/grammyjs/types/pull/45/ 
- [ ] add scope into the fuzzy match filter