### PR TITLE
fix: filter out regex names from .toArgs

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -232,6 +232,10 @@ export class Commands<C extends Context> {
                                 : local.name,
                             language,
                             prefix: command.prefix,
+                            scopes: command.scopes,
+                            description: command.getLocalizedDescription(
+                                language,
+                            ),
                         });
                     }
                     if (filterLanguage) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -157,9 +157,9 @@ export class Commands<C extends Context> {
                     language_code: language === "default"
                         ? undefined
                         : language,
-                    commands: commands.map((command) =>
-                        command.toObject(language)
-                    ),
+                    commands: commands
+                        .filter((command) => typeof command.name === "string")
+                        .map((command) => command.toObject(language)),
                 });
             }
         }

--- a/src/context.ts
+++ b/src/context.ts
@@ -107,7 +107,7 @@ export class MyCommandParams {
             .command("do b",
                      "b description",
                      (ctx) => ctx.doB());
-        const mergedParams = 
+        const mergedParams =
             MyCommandParams.from([a, b], someChatId);
         ```
      * @param commands An array of one or more Commands instances.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { LanguageCode } from "./deps.deno.ts";
+import type { BotCommandScope, LanguageCode } from "./deps.deno.ts";
 
 /**
  * Supported command options
@@ -29,4 +29,6 @@ export interface CommandElementals {
     name: string;
     prefix: string;
     language: LanguageCode | "default";
+    scopes: BotCommandScope[];
+    description: string;
 }

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -1,4 +1,3 @@
-import { assertArrayIncludes } from "https://deno.land/std@0.203.0/assert/assert_array_includes.ts";
 import {
     distance,
     fuzzyMatch,
@@ -108,59 +107,75 @@ describe("Jaro-Wrinkler Algorithm", () => {
         describe("toNameAndPrefix", () => {
             const cmds = new Commands<Context>();
             cmds.command("butcher", "_", () => {}, { prefix: "?" })
-                .localize("es", "carnicero", "_")
-                .localize("it", "macellaio", "_");
+                .localize("es", "carnicero", "a")
+                .localize("it", "macellaio", "b");
 
             cmds.command("duke", "_", () => {})
-                .localize("es", "duque", "_")
-                .localize("fr", "duc", "_");
+                .localize("es", "duque", "c")
+                .localize("fr", "duc", "d");
 
+            cmds.command(/dad_(.*)/, "dad", () => {})
+                .localize('es', /papa_(.*)/, "f",);
             it("should output all commands names, language and prefix", () => {
                 const json = cmds.toElementals();
-                assertArrayIncludes(json, [
+                assertEquals(json, [
                     {
-                        name: "butcher",
-                        language: "default",
-                        prefix: "?",
-                        scopes: [{ type: "default" }],
-                        description: "_",
+                      name: "butcher",
+                      language: "default",
+                      prefix: "?",
+                      scopes: [ { type: "default" } ],
+                      description: "_"
                     },
                     {
-                        name: "carnicero",
-                        language: "es",
-                        prefix: "?",
-                        scopes: [{ type: "default" }],
-                        description: "_",
+                      name: "carnicero",
+                      language: "es",
+                      prefix: "?",
+                      scopes: [ { type: "default" } ],
+                      description: "a"
                     },
                     {
-                        name: "macellaio",
-                        language: "it",
-                        prefix: "?",
-                        scopes: [{ type: "default" }],
-                        description: "_",
+                      name: "macellaio",
+                      language: "it",
+                      prefix: "?",
+                      scopes: [ { type: "default" } ],
+                      description: "b"
                     },
                     {
-                        name: "duke",
-                        language: "default",
-                        prefix: "/",
-                        scopes: [{ type: "default" }],
-                        description: "_",
+                      name: "duke",
+                      language: "default",
+                      prefix: "/",
+                      scopes: [ { type: "default" } ],
+                      description: "_"
                     },
                     {
-                        name: "duque",
-                        language: "es",
-                        prefix: "/",
-                        scopes: [{ type: "default" }],
-                        description: "_",
+                      name: "duque",
+                      language: "es",
+                      prefix: "/",
+                      scopes: [ { type: "default" } ],
+                      description: "c"
                     },
                     {
-                        name: "duc",
-                        language: "fr",
-                        prefix: "/",
-                        scopes: [{ type: "default" }],
-                        description: "_",
+                      name: "duc",
+                      language: "fr",
+                      prefix: "/",
+                      scopes: [ { type: "default" } ],
+                      description: "d"
                     },
-                ]);
+                    {
+                      name: "dad_(.*)",
+                      language: "default",
+                      prefix: "/",
+                      scopes: [ { type: "default" } ],
+                      description: "dad"
+                    },
+                    {
+                      name: "papa_(.*)",
+                      language: "es",
+                      prefix: "/",
+                      scopes: [ { type: "default" } ],
+                      description: "f"
+                    }
+                  ]);
             });
         });
         describe("should return the command localization related to the user lang", () => {

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -118,12 +118,48 @@ describe("Jaro-Wrinkler Algorithm", () => {
             it("should output all commands names, language and prefix", () => {
                 const json = cmds.toElementals();
                 assertArrayIncludes(json, [
-                    { name: "butcher", language: "default", prefix: "?" },
-                    { name: "carnicero", language: "es", prefix: "?" },
-                    { name: "macellaio", language: "it", prefix: "?" },
-                    { name: "duke", language: "default", prefix: "/" },
-                    { name: "duque", language: "es", prefix: "/" },
-                    { name: "duc", language: "fr", prefix: "/" },
+                    {
+                        name: "butcher",
+                        language: "default",
+                        prefix: "?",
+                        scopes: [{ type: "default" }],
+                        description: "_",
+                    },
+                    {
+                        name: "carnicero",
+                        language: "es",
+                        prefix: "?",
+                        scopes: [{ type: "default" }],
+                        description: "_",
+                    },
+                    {
+                        name: "macellaio",
+                        language: "it",
+                        prefix: "?",
+                        scopes: [{ type: "default" }],
+                        description: "_",
+                    },
+                    {
+                        name: "duke",
+                        language: "default",
+                        prefix: "/",
+                        scopes: [{ type: "default" }],
+                        description: "_",
+                    },
+                    {
+                        name: "duque",
+                        language: "es",
+                        prefix: "/",
+                        scopes: [{ type: "default" }],
+                        description: "_",
+                    },
+                    {
+                        name: "duc",
+                        language: "fr",
+                        prefix: "/",
+                        scopes: [{ type: "default" }],
+                        description: "_",
+                    },
                 ]);
             });
         });


### PR DESCRIPTION
this will fix #24 only for regex's.
Command names containing UpperCase letters will still thrown when calling `SetMyCommand` on them.

They should at least be discouraged. I don't know if it's better to enforce right from the bat the use of lowercaseonly commands or just a mention in the docs. Because they will still register and be handled correctly, but could not be pass to `SetMyCommand`
