### PR TITLE
feat: add `commandNotFound` filter / helper function for setting up a `did you mean?` handler and rename Commands class name

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -123,7 +123,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
      *
      * @example
      * ```ts
-     * const myCommands = new Commands();
+     * const myCommands = new CommandGroup();
      * myCommands.command("start", "Initializes bot configuration")
      *     .addToScope(
      *         { type: "all_private_chats" },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -305,7 +305,7 @@ export class CommandGroup<C extends Context> {
     }
 }
 
-type haveCommandLike<
+type HaveCommandLike<
     C extends Context = Context,
     CF extends CommandsFlavor<C> = CommandsFlavor<C>,
 > = C & CF & {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -305,17 +305,18 @@ export class CommandGroup<C extends Context> {
     }
 }
 
-type haveCommandLike<C extends Context & CommandsFlavor<C>> = C & {
-    commandSuggestion: string | null;
-};
-
-export function commandNotFound<C extends Context & CommandsFlavor<C>>(
+export function commandNotFound<
+    CF extends CommandsFlavor<C>,
+    C extends Context = Context,
+>(
     commands: CommandGroup<C> | CommandGroup<C>[],
     opts: Omit<Partial<JaroWinklerOptions>, "language"> = {},
 ) {
     return function (
         ctx: C,
-    ): ctx is haveCommandLike<C> {
+    ): ctx is C & CF & {
+        commandSuggestion: string | null;
+    } {
         if (containsCommands(ctx, commands)) {
             ctx.commandSuggestion = ctx.getNearestCommand(commands, opts);
             return true;
@@ -324,10 +325,15 @@ export function commandNotFound<C extends Context & CommandsFlavor<C>>(
     };
 }
 
-function containsCommands<C extends Context & CommandsFlavor<C>>(
+function containsCommands<
+    CF extends CommandsFlavor<C>,
+    C extends Context,
+>(
     ctx: C,
     commands: CommandGroup<C> | CommandGroup<C>[],
-): ctx is haveCommandLike<C> {
+): ctx is C & CF & {
+    commandSuggestion: string | null;
+} {
     const allPrefixes = [
         ...new Set(ensureArray(commands).flatMap((cmds) => cmds.prefixes)),
     ];

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -321,10 +321,10 @@ export function commandNotFound<
 ) {
     return function (
         ctx: C,
-    ): ctx is haveCommandLike<C, CF> {
+    ): ctx is HaveCommandLike<C, CF> {
         if (containsCommands(ctx, commands)) {
-            (ctx as haveCommandLike<C, CF>)
-                .commandSuggestion = (ctx as haveCommandLike<C, CF>)
+            (ctx as HaveCommandLike<C, CF>)
+                .commandSuggestion = (ctx as HaveCommandLike<C, CF>)
                     .getNearestCommand(commands, opts);
             return true;
         }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -305,13 +305,17 @@ export class CommandGroup<C extends Context> {
     }
 }
 
+type haveCommandLike<C extends Context & CommandsFlavor<C>> = C & {
+    commandSuggestion: string | null;
+};
+
 export function commandNotFound<C extends Context & CommandsFlavor<C>>(
     commands: CommandGroup<C> | CommandGroup<C>[],
     opts: Omit<Partial<JaroWinklerOptions>, "language"> = {},
 ) {
     return function (
         ctx: C,
-    ): ctx is haveCommands<C> {
+    ): ctx is haveCommandLike<C> {
         if (containsCommands(ctx, commands)) {
             ctx.commandSuggestion = ctx.getNearestCommand(commands, opts);
             return true;
@@ -323,7 +327,7 @@ export function commandNotFound<C extends Context & CommandsFlavor<C>>(
 function containsCommands<C extends Context & CommandsFlavor<C>>(
     ctx: C,
     commands: CommandGroup<C> | CommandGroup<C>[],
-): ctx is haveCommands<C> {
+): ctx is haveCommandLike<C> {
     const allPrefixes = [
         ...new Set(ensureArray(commands).flatMap((cmds) => cmds.prefixes)),
     ];
@@ -333,7 +337,3 @@ function containsCommands<C extends Context & CommandsFlavor<C>>(
     }
     return false;
 }
-
-type haveCommands<C extends Context & CommandsFlavor<C>> = C & {
-    commandSuggestion: string | null;
-};

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -50,14 +50,14 @@ const isMiddleware = <C extends Context>(
  *
  * @example
  * ```typescript
- * const myCommands = new Commands()
+ * const myCommands = new CommandGroup()
  * commands.command("start", "start the bot configuration", (ctx) => ctx.reply("Hello there!"))
  *
  * // Registers the commands with the bot instance.
  * bot.use(myCommands)
  * ```
  */
-export class Commands<C extends Context> {
+export class CommandGroup<C extends Context> {
     private _languages: Set<LanguageCode | "default"> = new Set();
     private _scopes: Map<string, Array<Command<C>>> = new Map();
     private _commands: Command<C>[] = [];

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,7 +3,7 @@ import { BotCommandScopeChat, Context, NextFunction } from "./deps.deno.ts";
 import { fuzzyMatch, JaroWinklerOptions } from "./jaro-winkler.ts";
 import { SetMyCommandsParams } from "./mod.ts";
 import { BotCommandEntity } from "./types.ts";
-import { ensureArray, escapeSpecial } from "./utils.ts";
+import { ensureArray, getCommandsRegex } from "./utils.ts";
 
 export interface CommandsFlavor<C extends Context = Context> extends Context {
     /**
@@ -122,13 +122,7 @@ export function commands<C extends Context>() {
             if (!prefixes.length) return [];
 
             const regexes = prefixes.map(
-                (prefix) =>
-                    new RegExp(
-                        `(\?\<\!\\S)(\?<prefix>${
-                            escapeSpecial(prefix)
-                        })\\S+(\\s|$)`,
-                        "g",
-                    ),
+                (prefix) => getCommandsRegex(prefix),
             );
             const entities = regexes.flatMap((regex) => {
                 let match: RegExpExecArray | null;

--- a/src/jaro-winkler.ts
+++ b/src/jaro-winkler.ts
@@ -1,4 +1,4 @@
-import { Commands } from "./commands.ts";
+import { CommandGroup } from "./commands.ts";
 import { Context, LanguageCode, LanguageCodes } from "./deps.deno.ts";
 import type { CommandElementals } from "./types.ts";
 
@@ -121,7 +121,7 @@ export function isLanguageCode(
 
 export function fuzzyMatch<C extends Context>(
     userInput: string,
-    commands: Commands<C>,
+    commands: CommandGroup<C>,
     options: Partial<JaroWinklerOptions>,
 ): CommandSimilarity | null {
     const defaultSimilarityThreshold = 0.82;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,9 @@ export function escapeSpecial(str: string) {
         str,
     );
 }
+export function getCommandsRegex(prefix: string) {
+    return new RegExp(
+        `(\?\<\!\\S)(\?<prefix>${escapeSpecial(prefix)})\\S+(\\s|$)`,
+        "g",
+    );
+}

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,4 +1,4 @@
-import { Commands } from "../src/commands.ts";
+import { CommandGroup } from "../src/commands.ts";
 import { MyCommandParams } from "../src/mod.ts";
 import { dummyCtx } from "./context.test.ts";
 import {
@@ -13,14 +13,14 @@ import {
 describe("Commands", () => {
     describe("command", () => {
         it("should create a command with no handlers", () => {
-            const commands = new Commands();
+            const commands = new CommandGroup();
             commands.command("test", "no handler");
 
             assertEquals(commands.toArgs(), []);
         });
 
         it("should create a command with a default handler", () => {
-            const commands = new Commands();
+            const commands = new CommandGroup();
             commands.command("test", "default handler", () => {}, {
                 prefix: undefined,
             });
@@ -33,7 +33,7 @@ describe("Commands", () => {
         });
 
         it("should support options with no handler", () => {
-            const commands = new Commands();
+            const commands = new CommandGroup();
             commands.command("test", "no handler", { prefix: "test" });
             assertEquals(
                 (commands as any)._commands[0]._options.prefix,
@@ -42,7 +42,7 @@ describe("Commands", () => {
         });
 
         it("should support options with default handler", () => {
-            const commands = new Commands();
+            const commands = new CommandGroup();
             commands.command("test", "default handler", () => {}, {
                 prefix: "test",
             });
@@ -55,12 +55,12 @@ describe("Commands", () => {
     describe("setMyCommands", () => {
         it("should throw if the update has no chat property", () => {
             const ctx = dummyCtx({ noMessage: true });
-            const a = new Commands();
+            const a = new CommandGroup();
             assertRejects(() => ctx.setMyCommands(a));
         });
         describe("toSingleScopeArgs", () => {
             it("should omit regex commands", () => {
-                const commands = new Commands();
+                const commands = new CommandGroup();
                 commands.command("test", "handler1", (_) => _);
                 commands.command("test2", "handler2", (_) => _);
                 commands.command(/omitMe_\d\d/, "handler3", (_) => _);
@@ -80,7 +80,7 @@ describe("Commands", () => {
                 ]);
             });
             it("should return an array with the localized versions of commands", () => {
-                const commands = new Commands();
+                const commands = new CommandGroup();
                 commands.command("test", "handler1", (_) => _).localize(
                     "es",
                     "prueba1",
@@ -126,7 +126,7 @@ describe("Commands", () => {
                 ]);
             });
             it("should omit commands with no handler", () => {
-                const commands = new Commands();
+                const commands = new CommandGroup();
                 commands.command("test", "handler", (_) => _);
                 commands.command("omitme", "nohandler");
                 const params = commands.toSingleScopeArgs({
@@ -146,11 +146,11 @@ describe("Commands", () => {
         });
         describe("merge MyCommandsParams", () => {
             it("should merge command's from different Commands instances", () => {
-                const a = new Commands();
+                const a = new CommandGroup();
                 a.command("a", "test a", (_) => _);
-                const b = new Commands();
+                const b = new CommandGroup();
                 b.command("b", "test b", (_) => _);
-                const c = new Commands();
+                const c = new CommandGroup();
                 c.command("c", "test c", (_) => _);
 
                 const mergedCommands = MyCommandParams.from([a, b, c], 10);
@@ -168,7 +168,7 @@ describe("Commands", () => {
                 ]);
             });
             it("should merge for localized scopes", () => {
-                const a = new Commands();
+                const a = new CommandGroup();
                 a.command("a", "test a", (_) => _);
                 a.command("a1", "test a1", (_) => _).localize(
                     "es",
@@ -181,7 +181,7 @@ describe("Commands", () => {
                     "test a2 localisé",
                 );
 
-                const b = new Commands();
+                const b = new CommandGroup();
                 b.command("b", "test b", (_) => _)
                     .localize("es", "localB", "prueba b localizada")
                     .localize("fr", "localiseB", "prueba b localisé");
@@ -234,7 +234,7 @@ describe("Commands", () => {
             });
         });
         describe("get all prefixes registered in a Commands instance", () => {
-            const a = new Commands();
+            const a = new CommandGroup();
             a.command("a", "/", (_) => _);
             a.command("a2", "/", (_) => _);
             a.command("b", "?", (_) => _, {
@@ -246,7 +246,7 @@ describe("Commands", () => {
             assertEquals(a.prefixes, ["/", "?", "abcd"]);
         });
         describe("get Entities from an update", () => {
-            const a = new Commands();
+            const a = new CommandGroup();
             a.command("a", "/", (_) => _);
             a.command("b", "?", (_) => _, {
                 prefix: "?",
@@ -255,9 +255,9 @@ describe("Commands", () => {
                 prefix: "abcd",
             });
 
-            const b = new Commands();
+            const b = new CommandGroup();
             b.command("one", "normal", (_) => _, { prefix: "superprefix" });
-            const c = new Commands();
+            const c = new CommandGroup();
 
             it("should only consider as entities prefixes registered in the command instance", () => {
                 const text = "/papi hola papacito como estamos /papi /ecco";

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -3,20 +3,13 @@ import {
     fuzzyMatch,
     JaroWinklerDistance,
 } from "../src/jaro-winkler.ts";
-import { CommandGroup, commands, CommandsFlavor } from "../src/mod.ts";
+import { CommandGroup } from "../src/mod.ts";
 import {
-    Api,
     assertEquals,
-    assertObjectMatch,
     assertThrows,
-    Chat,
     Context,
     describe,
     it,
-    Message,
-    Update,
-    User,
-    UserFromGetMe,
 } from "./deps.test.ts";
 import { dummyCtx } from "./context.test.ts";
 

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -3,7 +3,7 @@ import {
     fuzzyMatch,
     JaroWinklerDistance,
 } from "../src/jaro-winkler.ts";
-import { Commands, commands, CommandsFlavor } from "../src/mod.ts";
+import { CommandGroup, commands, CommandsFlavor } from "../src/mod.ts";
 import {
     Api,
     assertEquals,
@@ -42,7 +42,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
 
     describe("Fuzzy Matching", () => {
         it("should return the found command", () => {
-            const cmds = new Commands<Context>();
+            const cmds = new CommandGroup<Context>();
 
             cmds.command(
                 "start",
@@ -56,7 +56,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
 
         it("should return null because command doesn't exist", () => {
-            const cmds = new Commands<Context>();
+            const cmds = new CommandGroup<Context>();
 
             cmds.command(
                 "start",
@@ -71,7 +71,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
 
         it("should work for simple regex commands", () => {
-            const cmds = new Commands<Context>();
+            const cmds = new CommandGroup<Context>();
             cmds.command(
                 /magical_\d/,
                 "Magical Command",
@@ -85,7 +85,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             );
         });
         it("should work for localized regex", () => {
-            const cmds = new Commands<Context>();
+            const cmds = new CommandGroup<Context>();
             cmds.command(
                 /magical_(a|b)/,
                 "Magical Command",
@@ -106,7 +106,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
     });
     describe("Serialize commands for FuzzyMatch", () => {
         describe("toNameAndPrefix", () => {
-            const cmds = new Commands<Context>();
+            const cmds = new CommandGroup<Context>();
             cmds.command("butcher", "_", () => {}, { prefix: "?" })
                 .localize("es", "carnicero", "a")
                 .localize("it", "macellaio", "b");
@@ -180,7 +180,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             });
         });
         describe("should return the command localization related to the user lang", () => {
-            const cmds = new Commands<Context>();
+            const cmds = new CommandGroup<Context>();
             cmds.command("duke", "sniper", () => {})
                 .localize("es", "duque", "_")
                 .localize("fr", "duc", "_")
@@ -270,7 +270,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
             });
         });
         describe("should return the command localization related to the user lang for similar command names from different command classes", () => {
-            const cmds = new Commands<Context>();
+            const cmds = new CommandGroup<Context>();
             cmds.command("push", "push", () => {})
                 .localize("fr", "pousser", "a")
                 .localize("pt", "empurrar", "b");
@@ -334,7 +334,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
     });
     describe("Usage inside ctx", () => {
-        const cmds = new Commands<Context>();
+        const cmds = new CommandGroup<Context>();
         cmds.command("butcher", "_", () => {}, { prefix: "+" })
             .localize("es", "carnicero", "_")
             .localize("it", "macellaio", "_");
@@ -490,12 +490,12 @@ describe("Jaro-Wrinkler Algorithm", () => {
         });
     });
     describe("Test multiple commands instances", () => {
-        const cmds = new Commands<Context>();
+        const cmds = new CommandGroup<Context>();
         cmds.command("bread", "_", () => {})
             .localize("es", "pan", "_")
             .localize("fr", "pain", "_");
 
-        const cmds2 = new Commands<Context>();
+        const cmds2 = new CommandGroup<Context>();
 
         cmds2.command("dad", "_", () => {})
             .localize("es", "papa", "_")

--- a/test/not-found.test.ts
+++ b/test/not-found.test.ts
@@ -1,0 +1,87 @@
+import { CommandsFlavor } from "../src/context.ts";
+import { CommandGroup, commandNotFound } from "../src/mod.ts";
+import { dummyCtx } from "./context.test.ts";
+import {
+    assert,
+    assertEquals,
+    assertFalse,
+    Context,
+    describe,
+    it,
+} from "./deps.test.ts";
+
+describe("commandNotFound", () => {
+    describe("for inputs containing '/' commands", () => {
+        const ctx = dummyCtx({ userInput: "/papacin /papazote" });
+        it("should return true  when no commands are registered", () => {
+            const cmds = new CommandGroup();
+            const predicate = commandNotFound(cmds);
+            assert(predicate(ctx));
+        });
+        it("should return true when only '/' commands are registered", () => {
+            const cmds = new CommandGroup();
+            cmds.command("papacito", "", (_) => _);
+            const predicate = commandNotFound(cmds);
+            assert(predicate(ctx));
+        });
+        it("should return false when there is only custom prefixed commands registered", () => {
+            const cmds = new CommandGroup();
+            cmds.command("papazote", "", (_) => _, { prefix: "?" });
+            const predicate = commandNotFound(cmds);
+            assertFalse(predicate(ctx));
+        });
+    });
+    describe("for inputs containing custom prefixed commands", () => {
+        const ctx = dummyCtx({ userInput: "?papacin +papazote" });
+
+        it("should return false if only '/' commands are registered", () => {
+            const cmds = new CommandGroup();
+            cmds.command("papacito", "", (_) => _);
+            const predicate = commandNotFound(cmds);
+            assertFalse(predicate(ctx));
+        });
+        it("should return false for customs registered not matching the input", () => {
+            const cmds = new CommandGroup();
+            cmds.command("papacito", "", (_) => _, { prefix: "&" });
+            const predicate = commandNotFound(cmds);
+            assertFalse(predicate(ctx));
+        });
+        it("should return true for exact matching the input", () => {
+            const cmds = new CommandGroup();
+            cmds.command("papacin", "", (_) => _, { prefix: "?" });
+            cmds.command("papazote", "", (_) => _, { prefix: "+" });
+            const predicate = commandNotFound(cmds);
+            assert(predicate(ctx));
+        });
+        it("should return true for customs prefixed registered matching the input", () => {
+            const cmds = new CommandGroup();
+            cmds.command("papacin", "", (_) => _, { prefix: "+" });
+            cmds.command("papazote", "", (_) => _, { prefix: "?" });
+            const predicate = commandNotFound(cmds);
+            assert(predicate(ctx));
+        });
+    });
+    describe("ctx.commandSuggestion", () => {
+        type withSuggestion =
+            & CommandsFlavor<Context>
+            & { commandSuggestion: string | null };
+
+        const cmds = new CommandGroup();
+        cmds.command("papazote", "", (_) => _);
+        cmds.command("papacin", "", (_) => _, { prefix: "+" });
+        const predicate = commandNotFound(cmds);
+
+        it("should contain the proper suggestion ", () => {
+            const ctx = dummyCtx({ userInput: "/papacin" }) as withSuggestion;
+            predicate(ctx);
+            assertEquals(ctx.commandSuggestion, "+papacin");
+        });
+        it("should be null when the input does not match a suggestion", () => {
+            const ctx = dummyCtx({
+                userInput: "/nonadapapi",
+            }) as withSuggestion;
+            predicate(ctx);
+            assertEquals(ctx.commandSuggestion, null);
+        });
+    });
+});


### PR DESCRIPTION
Major changes: 
- rename Commands class into CommandGroup as per [this discussion](https://github.com/grammyjs/website/pull/1018#discussion_r1650259357)
- add `commandNotFound` helper function

Allows:
```ts
bot.use(userCommands)
bot.filter(commandNotFound(userCommands), async (ctx) => {
    if (ctx.commandSuggestion) {
        await ctx.reply(
            `Did you mean ${ctx.commandSuggestion}`
        )
    } else {
        await ctx.reply(`I didn't recognize that command`)
    }
})
```