### PR TITLE
feat: add import of commands + small fixes related to command options

### DIFF
--- a/src/command-group.ts
+++ b/src/command-group.ts
@@ -20,6 +20,7 @@ import {
   SetBotCommandsOptions,
 } from "./utils/set-bot-commands.ts";
 import { JaroWinklerOptions } from "./utils/jaro-winkler.ts";
+import { isMiddleware } from "./utils/checks.ts";
 
 /**
  * Interface for grouping {@link BotCommand}s that might (or not)
@@ -48,23 +49,6 @@ export interface UncompliantCommand {
   /** Language in which the command is uncompliant */
   language: LanguageCode | "default";
 }
-
-const isMiddleware = <C extends Context>(
-  obj: unknown,
-): obj is MaybeArray<Middleware<C>> => {
-  if (!obj) return false;
-  if (Array.isArray(obj)) return obj.every(isMiddleware);
-  const objType = typeof obj;
-
-  switch (objType) {
-    case "function":
-      return true;
-    case "object":
-      return Object.keys(obj).includes("middleware");
-  }
-
-  return false;
-};
 
 /**
  * Central class that manages all registered commands.

--- a/src/command-group.ts
+++ b/src/command-group.ts
@@ -75,6 +75,9 @@ export class CommandGroup<C extends Context> {
 
   constructor(options: Partial<CommandOptions> = {}) {
     this._commandOptions = options;
+    if (this._commandOptions.prefix?.trim() === "") {
+      this._commandOptions.prefix = "/";
+    }
   }
 
   private _addCommandToScope(scope: BotCommandScope, command: Command<C>) {

--- a/src/command-group.ts
+++ b/src/command-group.ts
@@ -140,7 +140,6 @@ export class CommandGroup<C extends Context> {
       : { ...this._commandOptions, ..._options };
 
     const command = new Command<C>(name, description, handler, options);
-    if (handler) command.addToScope({ type: "default" }, handler);
 
     this._commands.push(command);
     this._cachedComposerInvalidated = true;

--- a/src/command.ts
+++ b/src/command.ts
@@ -14,30 +14,11 @@ import {
 import { InvalidScopeError } from "./utils/errors.ts";
 import type { CommandOptions } from "./types.ts";
 import { ensureArray, type MaybeArray } from "./utils/array.ts";
+import { isAdmin, isMiddleware, matchesPattern } from "./utils/checks.ts";
 
 type BotCommandGroupsScope =
   | BotCommandScopeAllGroupChats
   | BotCommandScopeAllChatAdministrators;
-
-const isAdmin = (ctx: Context) =>
-  ctx
-    .getAuthor()
-    .then((author) => ["administrator", "creator"].includes(author.status));
-
-export const matchesPattern = (
-  value: string,
-  pattern: string | RegExp,
-  ignoreCase = false,
-) => {
-  const transformedValue = ignoreCase ? value.toLowerCase() : value;
-  const transformedPattern =
-    pattern instanceof RegExp && ignoreCase && !pattern.flags.includes("i")
-      ? new RegExp(pattern, pattern.flags + "i")
-      : pattern;
-  return typeof transformedPattern === "string"
-    ? transformedValue === transformedPattern
-    : transformedPattern.test(transformedValue);
-};
 
 const NOCASE_COMMAND_NAME_REGEX = /^[0-9a-z_]+$/i;
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -117,7 +117,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
       : options;
 
     this._options = { ...this._options, ...options };
-    if (this._options.prefix.trim() === "") this._options.prefix = "/";
+    if (this._options.prefix?.trim() === "") this._options.prefix = "/";
     this._languages.set("default", { name: name, description });
     if (handler) {
       this.addToScope({ type: "default" }, handler);

--- a/src/command.ts
+++ b/src/command.ts
@@ -48,7 +48,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
   /**
    * Initialize a new command with a default handler.
    *
-   * [!IMPORTANT] This class by its own does nothing. It needs to be imported into a commandGroup
+   * [!IMPORTANT] This class by its own does nothing. It needs to be imported into a `CommandGroup`
    * via the `add` method.
    *
    * @example
@@ -73,7 +73,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
   /**
    * Initialize a new command with no handlers.
    *
-   * [!IMPORTANT] This class by its own does nothing. It needs to be imported into a commandGroup
+   * [!IMPORTANT] This class by its own does nothing. It needs to be imported into a `CommandGroup`
    * via the `add` method
    *
    * @example

--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -1,0 +1,40 @@
+import { Context, Middleware } from "../deps.deno.ts";
+import { MaybeArray } from "./array.ts";
+
+export function isAdmin(ctx: Context) {
+  return ctx
+    .getAuthor()
+    .then((author) => ["administrator", "creator"].includes(author.status));
+}
+
+export function isMiddleware<C extends Context = Context>(
+  obj: unknown,
+): obj is MaybeArray<Middleware<C>> {
+  if (!obj) return false;
+  if (Array.isArray(obj)) return obj.every(isMiddleware);
+  const objType = typeof obj;
+
+  switch (objType) {
+    case "function":
+      return true;
+    case "object":
+      return Object.keys(obj).includes("middleware");
+  }
+
+  return false;
+}
+
+export function matchesPattern(
+  value: string,
+  pattern: string | RegExp,
+  ignoreCase = false,
+) {
+  const transformedValue = ignoreCase ? value.toLowerCase() : value;
+  const transformedPattern =
+    pattern instanceof RegExp && ignoreCase && !pattern.flags.includes("i")
+      ? new RegExp(pattern, pattern.flags + "i")
+      : pattern;
+  return typeof transformedPattern === "string"
+    ? transformedValue === transformedPattern
+    : transformedPattern.test(transformedValue);
+}

--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -25,7 +25,7 @@ export function isMiddleware<C extends Context = Context>(
   return false;
 }
 export function isCommandOptions(obj: unknown): obj is Partial<CommandOptions> {
-  if (typeof obj !== "object" && !!obj) return false;
+  if (typeof obj !== "object" || !obj) return false;
   const { prefix, matchOnlyAtStart, targetedCommands, ignoreCase } =
     obj as Partial<CommandOptions>;
 

--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -1,4 +1,5 @@
 import { Context, Middleware } from "../deps.deno.ts";
+import { CommandOptions } from "../types.ts";
 import { MaybeArray } from "./array.ts";
 
 export function isAdmin(ctx: Context) {
@@ -20,6 +21,21 @@ export function isMiddleware<C extends Context = Context>(
     case "object":
       return Object.keys(obj).includes("middleware");
   }
+
+  return false;
+}
+export function isCommandOptions(obj: unknown): obj is Partial<CommandOptions> {
+  if (typeof obj !== "object" && !!obj) return false;
+  const { prefix, matchOnlyAtStart, targetedCommands, ignoreCase } =
+    obj as Partial<CommandOptions>;
+
+  if (typeof prefix === "string") return true;
+  if (typeof matchOnlyAtStart === "boolean") return true;
+  if (
+    targetedCommands &&
+    ["ignored", "optional", "required"].includes(targetedCommands)
+  ) return true;
+  if (typeof ignoreCase === "boolean") return true;
 
   return false;
 }

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -15,6 +15,7 @@ import {
   type User,
   type UserFromGetMe,
 } from "./deps.test.ts";
+import { isCommandOptions } from "../src/utils/checks.ts";
 
 describe("Command", () => {
   const u = { id: 42, first_name: "bot", is_bot: true } as User;
@@ -599,6 +600,38 @@ describe("Command", () => {
         "Command name has uppercase characters",
         "Command name has special characters ($). Only letters, digits and _ are allowed",
       ]);
+    });
+  });
+  describe("isCommandOptions", () => {
+    it("true when an object contains valid CommandOptions properties", () => {
+      let partialOpts: Partial<CommandOptions> = { prefix: "!" };
+      assert(isCommandOptions(partialOpts));
+      partialOpts = { matchOnlyAtStart: true };
+      assert(isCommandOptions(partialOpts));
+      partialOpts = { matchOnlyAtStart: false };
+      assert(isCommandOptions(partialOpts));
+      partialOpts = { targetedCommands: "ignored" };
+      assert(isCommandOptions(partialOpts));
+      partialOpts = { targetedCommands: "optional" };
+      assert(isCommandOptions(partialOpts));
+      partialOpts = { targetedCommands: "required" };
+      assert(isCommandOptions(partialOpts));
+      partialOpts = { ignoreCase: true };
+      assert(isCommandOptions(partialOpts));
+    });
+    it("should return false when an object contains invalid types for valid CommandOptions properties", () => {
+      let partialOpts: any = { prefix: true };
+      assertFalse(isCommandOptions(partialOpts));
+      partialOpts = { ignoreCase: "false" };
+      assertFalse(isCommandOptions(partialOpts));
+      partialOpts = { targetedCommands: "requirred" };
+      assertFalse(isCommandOptions(partialOpts));
+      partialOpts = { ignoreCase: 1 };
+      assertFalse(isCommandOptions(partialOpts));
+    });
+    it("should return false when an object does not contain any CommandOption property", () => {
+      let partialOpts: any = { papi: true };
+      assertFalse(isCommandOptions(partialOpts));
     });
   });
 });

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "https://deno.land/std@0.203.0/assert/assert_equals.ts";
-import { Command, matchesPattern } from "../src/command.ts";
+import { Command } from "../src/command.ts";
 import { CommandOptions } from "../src/types.ts";
+import { matchesPattern } from "../src/utils/checks.ts";
 import {
   Api,
   assert,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -4,7 +4,7 @@ import {
 } from "https://deno.land/std@0.203.0/testing/mock.ts";
 import { CommandGroup } from "../src/command-group.ts";
 import { Bot } from "../src/deps.deno.ts";
-import { commands, CommandsFlavor } from "../src/mod.ts";
+import { Command, commands, CommandsFlavor } from "../src/mod.ts";
 import {
   Api,
   assertRejects,
@@ -175,8 +175,25 @@ describe("Integration", () => {
       it("should add a command with a default handler", async () => {
         const handler = spy(() => {});
 
-        const commandGroup = new CommandGroup({ prefix: "!" });
-        commandGroup.command("command", "_", handler);
+        const commandGroup = new CommandGroup();
+        commandGroup.command("command", "_", handler, { prefix: "!" });
+
+        const bot = getBot();
+        bot.use(commands());
+        bot.use(commandGroup);
+
+        await bot.handleUpdate(getDummyUpdate({ userInput: "!command" }));
+
+        assertSpyCalls(handler, 1);
+      });
+    });
+    describe("add", () => {
+      it("should add a command that was statically created", async () => {
+        const handler = spy(() => {});
+
+        const commandGroup = new CommandGroup();
+        const cmd = new Command("command", "_", handler, { prefix: "!" });
+        commandGroup.add(cmd);
 
         const bot = getBot();
         bot.use(commands());


### PR DESCRIPTION
closes #38 
 ```ts
  const sayHi = new Command("hi","say hi", (ctx) => ctx.reply("hi"))
  const sayBye = new Command("bye","say bye", (ctx) => ctx.reply("bye"), { ignoreCase: true })
  const myCmds = new CommandGroup().add(sayHi).add(sayBye)
```

**fix:** merge options instead of complete override when using the `.command` creation method.

- when passing a `options` param to the `CommandGroup.command(...)` method, the default options from the command group now merges with the specific options of that command, which ofc takes priority. Before the object was being overridden completely, ignoring the default group options.
https://github.com/grammyjs/commands/blob/0f92ae16f08a1e8e991156eebd2c2fd2823f8c11/src/command-group.ts#L141-L143


**feat:** prevent whitespace only custom prefixes.

- improve the prevention for using whitespace only custom prefixes. Before it was checking only against `prefix === ""`
https://github.com/grammyjs/commands/blob/0f92ae16f08a1e8e991156eebd2c2fd2823f8c11/src/command-group.ts#L78-L79
https://github.com/grammyjs/commands/blob/0f92ae16f08a1e8e991156eebd2c2fd2823f8c11/src/command.ts#L120