### PR TITLE
Fix: deno task check/test

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -19,9 +19,9 @@
   "lock": false,
   "tasks": {
     "backport": "rm -rf out && deno run --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.9.0/src/cli.ts",
-    "check": "deno lint && deno fmt --check && deno check --allow-import src/mod.ts",
+    "check": "deno lint && deno fmt --check && deno check src/mod.ts",
     "fix": "deno lint --fix && deno fmt",
-    "test": "deno test --allow-import --seed=123456 --parallel ./test/",
+    "test": "deno test -r --seed=123456 --parallel ./test/",
     "coverage": "rm -rf ./test/cov_profile && deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
     "hook": "deno run --allow-read --allow-run --allow-write https://deno.land/x/deno_hooks@0.1.1/mod.ts"
   },

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -18,10 +18,10 @@
   },
   "lock": false,
   "tasks": {
-    "backport": "rm -rf out && deno run --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.9.0/src/cli.ts",
+    "backport": "rm -rf out && deno run -r --no-prompt --allow-read=. --allow-write=. --allow-import https://deno.land/x/deno2node@v1.9.0/src/cli.ts",
     "check": "deno lint && deno fmt --check && deno check src/mod.ts",
     "fix": "deno lint --fix && deno fmt",
-    "test": "deno test -r --seed=123456 --parallel ./test/",
+    "test": "deno test -r --allow-import --seed=123456 --parallel ./test/",
     "coverage": "rm -rf ./test/cov_profile && deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
     "hook": "deno run --allow-read --allow-run --allow-write https://deno.land/x/deno_hooks@0.1.1/mod.ts"
   },


### PR DESCRIPTION
- add reload flag to the `test` task
- remove the `allow-import` which looks to be useless and throws error

the `backport` task is failing because of #53 
