### PR TITLE
feat: fill `ctx.match` and add `ctx.commandMatch` and node chores

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -18,7 +18,7 @@
   },
   "lock": false,
   "tasks": {
-    "backport": "rm -rf out && deno run --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.9.0/src/cli.ts",
+    "backport": "deno run --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.14.0/src/cli.ts",
     "check": "deno lint && deno fmt --check && deno check --allow-import src/mod.ts",
     "fix": "deno lint --fix && deno fmt",
     "test": "deno test --allow-import --seed=123456 --parallel ./test/",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
-        "deno-bin": "^2.0.6",
+        "deno2node": "^1.14.0",
         "typescript": "^5.6.3"
       },
       "peerDependencies": {
@@ -22,6 +22,17 @@
       "integrity": "sha512-XQHJNlF6AuJgVPYL8mEWrYk4Pg/FoP9PryTVSObtf/SWRIk0dCBkIwSaGGoXa1VDrLVWl/dIP79FgS2acJJjdg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.25.0.tgz",
+      "integrity": "sha512-kMnZz+vGGHi4GoHnLmMhGNjm44kGtKUXGnOvrKmMwAuvNjM/PgKVGfUnL7IDvK7Jb2QQ82jq3Zmp04Gy+r3Dkg==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^9.0.4",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.9"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -36,15 +47,26 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -64,19 +86,19 @@
         }
       }
     },
-    "node_modules/deno-bin": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/deno-bin/-/deno-bin-2.0.6.tgz",
-      "integrity": "sha512-r+stiyToBRQIAzYmzuNHH+RpfgCfhtnScR6PG0EpN61WtJgWteND5cKOaK+ODYCObZoAlGZaMLv67mhfCnaUCQ==",
+    "node_modules/deno2node": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/deno2node/-/deno2node-1.14.0.tgz",
+      "integrity": "sha512-F1WpKb2OuIcMmev6tGFMzoQCJcsPTmZFymzP5mcq4Ac8xQwT4brWJqDL+LyKP9uqOPSAKU5QJi6ZIJPs4IKtSA==",
       "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.4"
+        "ts-morph": "^24.0.0"
       },
       "bin": {
-        "deno": "bin/deno.js",
-        "deno-bin": "bin/deno.js"
+        "deno2node": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.13.1"
       }
     },
     "node_modules/event-target-shim": {
@@ -87,6 +109,20 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "dev": true,
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/grammy": {
@@ -103,6 +139,21 @@
       },
       "engines": {
         "node": "^12.20.0 || >=14.13.1"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -133,12 +184,53 @@
         }
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.4.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/ts-morph": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-24.0.0.tgz",
+      "integrity": "sha512-2OAOg/Ob5yx9Et7ZX4CvTCc0UFoZHwLEJ+dpDPSUi5TgwwlTlX47w+iFRrEwzUZwYACjq83cgjS/Da50Ga37uw==",
+      "dev": true,
+      "dependencies": {
+        "@ts-morph/common": "~0.25.0",
+        "code-block-writer": "^13.0.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.6.3",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "grammY Commands Plugin",
   "main": "out/mod.js",
   "scripts": {
-    "backport": "deno task backport",
-    "prepare": "deno task backport"
+    "backport": "deno2node tsconfig.json",
+    "prepare": "npm run backport"
   },
   "keywords": [
     "grammY",
@@ -27,7 +27,7 @@
     "grammy": "^1.17.1"
   },
   "devDependencies": {
-    "deno-bin": "^2.0.6",
+    "deno2node": "^1.14.0",
     "typescript": "^5.6.3"
   },
   "files": [

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,5 @@
 import { CommandGroup } from "./command-group.ts";
+import { CommandMatch } from "./command.ts";
 import { BotCommandScopeChat, Context, NextFunction } from "./deps.deno.ts";
 import { SetMyCommandsParams } from "./mod.ts";
 import { BotCommandEntity } from "./types.ts";
@@ -36,6 +37,7 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
     commands: CommandGroup<C> | CommandGroup<C>[],
     options?: SetBotCommandsOptions,
   ) => Promise<void>;
+
   /**
    * Returns the nearest command to the user input.
    * If no command is found, returns `null`.
@@ -56,6 +58,13 @@ export interface CommandsFlavor<C extends Context = Context> extends Context {
   getCommandEntities: (
     commands: CommandGroup<C> | CommandGroup<C>[],
   ) => BotCommandEntity[];
+
+  /**
+   * The matched command and the rest of the input.
+   *
+   * When matched command is a RegExp, a `match` property exposes the result of the RegExp match.
+   */
+  commandMatch: CommandMatch;
 }
 
 /**


### PR DESCRIPTION
- Allow users to get the "arguments" of a command using `ctx.match`
- Expose result of RegExp match through `ctx.commandMatch`

Example usage:

```ts
type MyContext = Context & CommandsFlavor;

const bot = new Bot<MyContext>("TOKEN");

const commands = new CommandGroup<MyContext>();

commands.command(/start ?(?<name>.*)?/, "a", async (ctx) => {
  console.log(ctx.commandMatch);
  // { command: /start ?(?<name>.*)?/, rest: 'name', match: ['start name', 'name'] }

  return ctx.reply(`Hello`);
});

bot.use(commands);

bot.start({
  onStart: () => {
    console.log("Bot started");
  },
});
```

Closes #58