### PR TITLE
fix: composer not being recognized as valid middleware for default handler

### DIFF
--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -1,4 +1,4 @@
-import { Context, Middleware } from "../deps.deno.ts";
+import { Composer, Context, Middleware } from "../deps.deno.ts";
 import { CommandOptions } from "../types.ts";
 import { MaybeArray } from "./array.ts";
 
@@ -12,6 +12,7 @@ export function isMiddleware<C extends Context = Context>(
   obj: unknown,
 ): obj is MaybeArray<Middleware<C>> {
   if (!obj) return false;
+  if (obj instanceof Composer) return true;
   if (Array.isArray(obj)) return obj.every(isMiddleware);
   const objType = typeof obj;
 

--- a/test/utils-test.test.ts
+++ b/test/utils-test.test.ts
@@ -18,5 +18,10 @@ describe("Utils tests", () => {
       const composer = new Composer();
       assert(isMiddleware(composer));
     });
+    it("Composer[]", () => {
+      const a = new Composer();
+      const b = new Composer();
+      assert(isMiddleware([a, b]));
+    });
   });
 });

--- a/test/utils-test.test.ts
+++ b/test/utils-test.test.ts
@@ -14,7 +14,7 @@ import { Composer } from "../src/deps.deno.ts";
 
 describe("Utils tests", () => {
   describe("isMiddleware", () => {
-    it("recognize Composer as a valid middleware", () => {
+    it("Composer", () => {
       const composer = new Composer();
       assert(isMiddleware(composer));
     });

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -1,0 +1,22 @@
+import { isMiddleware } from "../src/utils/checks.ts";
+import { CommandsFlavor } from "../src/context.ts";
+import { CommandGroup, commandNotFound } from "../src/mod.ts";
+import { dummyCtx } from "./context.test.ts";
+import {
+  assert,
+  assertEquals,
+  assertFalse,
+  Context,
+  describe,
+  it,
+} from "./deps.test.ts";
+import { Composer } from "../src/deps.deno.ts";
+
+describe("Utils tests", () => {
+  describe("isMiddleware", () => {
+    it("recognize Composer as a valid middleware", () => {
+      const composer = new Composer();
+      assert(isMiddleware(composer));
+    });
+  });
+});


### PR DESCRIPTION
fixes
```ts
commands
  .command("start", "description")
  .addToScope({ type: "default" }, start);

const test = new Composer<AppContext>();

commands
  .command("test", "Teste")
  .addToScope({ type: "default" }, test); /* not being pick up*/ 
```