### PR TITLE
feat: ability to add command w/o handler to cmd menu. refactor: CommandElementals type

### DIFF
--- a/src/command-group.ts
+++ b/src/command-group.ts
@@ -275,13 +275,14 @@ export class CommandGroup<C extends Context> {
   }
 
   /**
-   * Serialize all register commands into it's name, prefix and language
+   * Serialize all register commands into a more detailed object
+   * including it's name, prefix and language, and more data
    *
    * @param filterLanguage if undefined, it returns all names
    * else get only the locales for the given filterLanguage
    * fallbacks to "default"
    *
-   * @returns an array of {@link CommandElementals}
+   * @returns an array of {@link BotCommandX}
    *
    * Note: mainly used to serialize for {@link FuzzyMatch}
    */

--- a/src/command-group.ts
+++ b/src/command-group.ts
@@ -34,7 +34,7 @@ export interface SetMyCommandsParams {
    */
   language_code?: LanguageCode;
   /** Commands that can be each one passed to a SetMyCommands Call */
-  commands: (BotCommand & { noHandler?: boolean })[];
+  commands: (BotCommand & { hasHandler?: boolean })[];
 }
 
 /**
@@ -310,7 +310,9 @@ export class CommandGroup<C extends Context> {
               description: command.getLocalizedDescription(
                 language,
               ),
-              ...(command.noHandler ? { noHandler: true } : {}),
+              ...(command.hasHandler
+                ? { hasHandler: true }
+                : { hasHandler: false }),
             });
           }
           if (filterLanguage) {

--- a/src/command-group.ts
+++ b/src/command-group.ts
@@ -34,7 +34,7 @@ export interface SetMyCommandsParams {
    */
   language_code?: LanguageCode;
   /** Commands that can be each one passed to a SetMyCommands Call */
-  commands: BotCommand[];
+  commands: (BotCommand & { noHandler?: boolean })[];
 }
 
 /**
@@ -309,6 +309,7 @@ export class CommandGroup<C extends Context> {
               description: command.getLocalizedDescription(
                 language,
               ),
+              ...(command.noHandler ? { noHandler: true } : {}),
             });
           }
           if (filterLanguage) {

--- a/src/command-group.ts
+++ b/src/command-group.ts
@@ -9,7 +9,7 @@ import {
   type LanguageCode,
   Middleware,
 } from "./deps.deno.ts";
-import type { CommandElementals, CommandOptions } from "./types.ts";
+import type { BotCommandX, CommandOptions } from "./types.ts";
 import {
   ensureArray,
   getCommandsRegex,
@@ -288,7 +288,7 @@ export class CommandGroup<C extends Context> {
 
   public toElementals(
     filterLanguage?: LanguageCode | "default",
-  ): CommandElementals[] {
+  ): BotCommandX[] {
     this._populateMetadata();
 
     return Array.from(this._scopes.values())
@@ -300,7 +300,7 @@ export class CommandGroup<C extends Context> {
             const [language, local] of command.languages.entries()
           ) {
             elements.push({
-              name: local.name instanceof RegExp
+              command: local.name instanceof RegExp
                 ? local.name.source
                 : local.name,
               language,

--- a/src/command.ts
+++ b/src/command.ts
@@ -66,7 +66,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
     targetedCommands: "optional",
     ignoreCase: false,
   };
-  private _noHandler: boolean;
+  private _hasHandler: boolean;
 
   /**
    * Initialize a new command with a default handler.
@@ -139,8 +139,8 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
 
     if (!handler) {
       handler = async (_ctx: Context, next: NextFunction) => await next();
-      this._noHandler = true;
-    } else this._noHandler = false;
+      this._hasHandler = false;
+    } else this._hasHandler = true;
 
     this._options = { ...this._options, ...options };
     if (this._options.prefix?.trim() === "") this._options.prefix = "/";
@@ -256,8 +256,8 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
    * Get if this command has a handler
    */
 
-  get noHandler(): boolean {
-    return this._noHandler;
+  get hasHandler(): boolean {
+    return this._hasHandler;
   }
 
   /**
@@ -519,14 +519,14 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
    */
   public toObject(
     languageCode: LanguageCode | "default" = "default",
-  ): Pick<BotCommandX, "command" | "description" | "noHandler"> {
+  ): Pick<BotCommandX, "command" | "description" | "hasHandler"> {
     const localizedName = this.getLocalizedName(languageCode);
     return {
       command: localizedName instanceof RegExp
         ? localizedName.source
         : localizedName,
       description: this.getLocalizedDescription(languageCode),
-      ...(this.noHandler ? { noHandler: true } : {}),
+      ...(this.hasHandler ? { hasHandler: true } : { hasHandler: false }),
     };
   }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -14,7 +14,7 @@ import {
   type MiddlewareObj,
   type NextFunction,
 } from "./deps.deno.ts";
-import type { CommandOptions } from "./types.ts";
+import type { BotCommandX, CommandOptions } from "./types.ts";
 import { ensureArray, type MaybeArray } from "./utils/array.ts";
 import {
   isAdmin,
@@ -520,7 +520,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
    */
   public toObject(
     languageCode: LanguageCode | "default" = "default",
-  ): BotCommand & { noHandler?: boolean } {
+  ): Pick<BotCommandX, "command" | "description" | "noHandler"> {
     const localizedName = this.getLocalizedName(languageCode);
     return {
       command: localizedName instanceof RegExp

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,6 +1,5 @@
 import { CommandsFlavor } from "./context.ts";
 import {
-  type BotCommand,
   type BotCommandScope,
   type BotCommandScopeAllChatAdministrators,
   type BotCommandScopeAllGroupChats,

--- a/src/command.ts
+++ b/src/command.ts
@@ -12,7 +12,7 @@ import {
   type LanguageCode,
   type Middleware,
   type MiddlewareObj,
-  NextFunction,
+  type NextFunction,
 } from "./deps.deno.ts";
 import type { CommandOptions } from "./types.ts";
 import { ensureArray, type MaybeArray } from "./utils/array.ts";

--- a/src/command.ts
+++ b/src/command.ts
@@ -255,7 +255,6 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
   /**
    * Get if this command has a handler
    */
-
   get hasHandler(): boolean {
     return this._hasHandler;
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -123,7 +123,7 @@ export function commands<C extends Context>() {
 
       if (!result || !result.command) return null;
 
-      return result.command.prefix + result.command.name;
+      return result.command.prefix + result.command.command;
     };
 
     ctx.getCommandEntities = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export interface BotCommandX extends BotCommand {
   /**
    * True if this command has middleware attach to it. False if not.
    */
-  hasHandler?: boolean;
+  hasHandler: boolean;
 }
 
 /** represents a bot__command entity inside a text message */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  BotCommand,
   BotCommandScope,
   LanguageCode,
   MessageEntity,
@@ -33,13 +34,11 @@ export interface CommandOptions {
    */
   ignoreCase: boolean;
 }
-
-export interface CommandElementals {
-  name: string;
+export interface CommandElementals extends Pick<BotCommand, "description"> {
+  name: BotCommand["command"];
   prefix: string;
   language: LanguageCode | "default";
   scopes: BotCommandScope[];
-  description: string;
   noHandler?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,9 +50,9 @@ export interface BotCommandX extends BotCommand {
    */
   scopes: BotCommandScope[];
   /**
-   * True if this command has no middleware attach to it. False if it has.
+   * True if this command has middleware attach to it. False if not.
    */
-  noHandler?: boolean;
+  hasHandler?: boolean;
 }
 
 /** represents a bot__command entity inside a text message */

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,10 +35,23 @@ export interface CommandOptions {
   ignoreCase: boolean;
 }
 
+/**
+ * BotCommand representation with more information about it.
+ * Specially in regards to the plugin manipulation of it
+ */
 export interface BotCommandX extends BotCommand {
   prefix: string;
+  /**
+   * Language in which this command is localize
+   */
   language: LanguageCode | "default";
+  /**
+   * Scopes in which this command is registered
+   */
   scopes: BotCommandScope[];
+  /**
+   * True if this command has middleware attach to it. False if not.
+   */
   noHandler?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  BotCommand,
   BotCommandScope,
   LanguageCode,
   MessageEntity,
@@ -34,12 +35,10 @@ export interface CommandOptions {
   ignoreCase: boolean;
 }
 
-export interface CommandElementals {
-  name: string;
+export interface BotCommandX extends BotCommand {
   prefix: string;
   language: LanguageCode | "default";
   scopes: BotCommandScope[];
-  description: string;
   noHandler?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export interface CommandElementals {
   language: LanguageCode | "default";
   scopes: BotCommandScope[];
   description: string;
+  noHandler?: boolean;
 }
 
 /** represents a bot__command entity inside a text message */

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export interface BotCommandX extends BotCommand {
    */
   scopes: BotCommandScope[];
   /**
-   * True if this command has middleware attach to it. False if not.
+   * True if this command has no middleware attach to it. False if it has.
    */
   noHandler?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import type {
-  BotCommand,
   BotCommandScope,
   LanguageCode,
   MessageEntity,
@@ -34,11 +33,13 @@ export interface CommandOptions {
    */
   ignoreCase: boolean;
 }
-export interface CommandElementals extends Pick<BotCommand, "description"> {
-  name: BotCommand["command"];
+
+export interface CommandElementals {
+  name: string;
   prefix: string;
   language: LanguageCode | "default";
   scopes: BotCommandScope[];
+  description: string;
   noHandler?: boolean;
 }
 

--- a/src/utils/jaro-winkler.ts
+++ b/src/utils/jaro-winkler.ts
@@ -1,6 +1,6 @@
 import { CommandGroup } from "../command-group.ts";
 import { Context, LanguageCode } from "../deps.deno.ts";
-import type { CommandElementals } from "../types.ts";
+import type { BotCommandX } from "../types.ts";
 import { LanguageCodes } from "../language-codes.ts";
 
 export function distance(s1: string, s2: string) {
@@ -79,7 +79,7 @@ export type JaroWinklerOptions = {
 };
 
 type CommandSimilarity = {
-  command: CommandElementals | null;
+  command: BotCommandX | null;
   similarity: number;
 };
 
@@ -142,7 +142,7 @@ export function fuzzyMatch<C extends Context>(
 
   const bestMatch = cmds.reduce(
     (best: CommandSimilarity, command) => {
-      const similarity = JaroWinklerDistance(userInput, command.name, {
+      const similarity = JaroWinklerDistance(userInput, command.command, {
         ...options,
       });
       return similarity > best.similarity ? { command, similarity } : best;

--- a/test/command-group.test.ts
+++ b/test/command-group.test.ts
@@ -34,11 +34,14 @@ describe("CommandGroup", () => {
         prefix: undefined,
       });
 
-      assertEquals(commands.toArgs().scopes, [{
+      const expected = [{
         commands: [{ command: "test", description: "default handler" }],
         language_code: undefined,
         scope: { type: "default" },
-      }]);
+      }];
+      commands.toArgs().scopes.forEach((commands, i) =>
+        assertObjectMatch(commands, expected[i])
+      );
     });
 
     it("should support options with no handler", () => {
@@ -77,16 +80,15 @@ describe("CommandGroup", () => {
           type: "chat",
           chat_id: 10,
         });
-        assertEquals(params.commandParams, [
-          {
-            scope: { type: "chat", chat_id: 10 },
-            language_code: undefined,
-            commands: [
-              { command: "test", description: "handler1" },
-              { command: "test2", description: "handler2" },
-            ],
-          },
-        ]);
+        const expected = [{
+          commands: [
+            { command: "test", description: "handler1" },
+            { command: "test2", description: "handler2" },
+          ],
+        }];
+        params.commandParams.forEach((commands, i) =>
+          assertObjectMatch(commands, expected[i])
+        );
       });
       it("should return an array with the localized versions of commands", () => {
         const commands = new CommandGroup();
@@ -106,7 +108,7 @@ describe("CommandGroup", () => {
           type: "chat",
           chat_id: 10,
         });
-        assertEquals(params.commandParams, [
+        const expected = [
           {
             scope: { type: "chat", chat_id: 10 },
             language_code: undefined,
@@ -132,7 +134,10 @@ describe("CommandGroup", () => {
               },
             ],
           },
-        ]);
+        ];
+        params.commandParams.forEach((command, i) =>
+          assertObjectMatch(command, expected[i])
+        );
       });
       it("should mark commands with no handler", () => {
         const commands = new CommandGroup();
@@ -147,7 +152,7 @@ describe("CommandGroup", () => {
             scope: { type: "chat", chat_id: 10 },
             language_code: undefined,
             commands: [
-              { command: "test", description: "handler" },
+              { command: "test", description: "handler", hasHandler: true },
               {
                 command: "markme",
                 description: "nohandler",
@@ -177,6 +182,7 @@ describe("CommandGroup", () => {
                 {
                   command: "withoutcustomprefix",
                   description: "handler",
+                  hasHandler: true,
                 },
               ],
             },
@@ -201,18 +207,18 @@ describe("CommandGroup", () => {
         c.command("c", "test c", (_) => _);
 
         const mergedCommands = MyCommandParams.from([a, b, c], 10);
-
-        assertEquals(mergedCommands.commandsParams, [
-          {
-            scope: { type: "chat", chat_id: 10 },
-            language_code: undefined,
-            commands: [
-              { command: "c", description: "test c" },
-              { command: "b", description: "test b" },
-              { command: "a", description: "test a" },
-            ],
-          },
-        ]);
+        const expected = [{
+          scope: { type: "chat", chat_id: 10 },
+          language_code: undefined,
+          commands: [
+            { command: "c", description: "test c" },
+            { command: "b", description: "test b" },
+            { command: "a", description: "test a" },
+          ],
+        }];
+        mergedCommands.commandsParams.forEach((command, i) =>
+          assertObjectMatch(command, expected[i])
+        );
       });
       it("should merge for localized scopes", () => {
         const a = new CommandGroup();
@@ -234,7 +240,7 @@ describe("CommandGroup", () => {
           .localize("fr", "localiseb", "prueba b localisé");
 
         const mergedCommands = MyCommandParams.from([a, b], 10);
-        assertEquals(mergedCommands.commandsParams, [
+        const expected = [
           {
             scope: { type: "chat", chat_id: 10 },
             language_code: undefined,
@@ -277,7 +283,10 @@ describe("CommandGroup", () => {
               },
             ],
           },
-        ]);
+        ];
+        mergedCommands.commandsParams.forEach((command, i) =>
+          assertObjectMatch(command, expected[i])
+        );
       });
     });
     describe("get all prefixes registered in a Commands instance", () => {
@@ -377,8 +386,7 @@ describe("CommandGroup", () => {
       commands.command("test2", "handler2", (_) => _)
         .localize("es", "prueba2", "resolvedor2");
       const params = commands.toArgs();
-
-      assertEquals(params.scopes, [
+      const expected = [
         {
           commands: [
             { command: "test", description: "handler" },
@@ -395,7 +403,10 @@ describe("CommandGroup", () => {
           language_code: "es",
           scope: { type: "default" },
         },
-      ]);
+      ];
+      params.scopes.forEach((command, i) =>
+        assertObjectMatch(command, expected[i])
+      );
     });
 
     it("should separate between compliant and uncompliant commands", () => {
@@ -415,6 +426,7 @@ describe("CommandGroup", () => {
               {
                 command: "withoutcustomprefix",
                 description: "handler",
+                hasHandler: true,
               },
             ],
           },

--- a/test/command-group.test.ts
+++ b/test/command-group.test.ts
@@ -4,6 +4,7 @@ import { dummyCtx } from "./context.test.ts";
 import {
   assert,
   assertEquals,
+  assertObjectMatch,
   assertRejects,
   assertThrows,
   describe,
@@ -16,7 +17,15 @@ describe("CommandGroup", () => {
       const commands = new CommandGroup();
       commands.command("test", "no handler");
 
-      assertEquals(commands.toArgs().scopes, []);
+      assertObjectMatch(commands.toArgs().scopes[0], {
+        commands: [
+          {
+            command: "test",
+            description: "no handler",
+            noHandler: true,
+          },
+        ],
+      });
     });
 
     it("should create a command with a default handler", () => {
@@ -125,10 +134,10 @@ describe("CommandGroup", () => {
           },
         ]);
       });
-      it("should omit commands with no handler", () => {
+      it("should mark commands with no handler", () => {
         const commands = new CommandGroup();
         commands.command("test", "handler", (_) => _);
-        commands.command("omitme", "nohandler");
+        commands.command("markme", "nohandler");
         const params = commands.toSingleScopeArgs({
           type: "chat",
           chat_id: 10,
@@ -139,6 +148,11 @@ describe("CommandGroup", () => {
             language_code: undefined,
             commands: [
               { command: "test", description: "handler" },
+              {
+                command: "markme",
+                description: "nohandler",
+                noHandler: true,
+              },
             ],
           },
         ]);

--- a/test/command-group.test.ts
+++ b/test/command-group.test.ts
@@ -22,7 +22,7 @@ describe("CommandGroup", () => {
           {
             command: "test",
             description: "no handler",
-            noHandler: true,
+            hasHandler: false,
           },
         ],
       });
@@ -151,7 +151,7 @@ describe("CommandGroup", () => {
               {
                 command: "markme",
                 description: "nohandler",
-                noHandler: true,
+                hasHandler: false,
               },
             ],
           },

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -96,20 +96,20 @@ describe("Integration", () => {
 
       assertSpyCalls(setMyCommandsSpy, 0);
     });
-    // it("should be hable to set commands with no handler", async () => {
-    //   const myCommands = new CommandGroup({ prefix: "!" });
-    //   myCommands.command("command", "super description");
+    it("should be hable to set commands with no handler", async () => {
+      const myCommands = new CommandGroup();
+      myCommands.command("command", "super description");
 
-    //   const setMyCommandsSpy = spy(resolvesNext([true] as const));
+      const setMyCommandsSpy = spy(resolvesNext([true] as const));
 
-    //   await myCommands.setCommands({
-    //     api: {
-    //       raw: { setMyCommands: setMyCommandsSpy },
-    //     } as unknown as Api,
-    //   });
+      await myCommands.setCommands({
+        api: {
+          raw: { setMyCommands: setMyCommandsSpy },
+        } as unknown as Api,
+      });
 
-    //   assertSpyCalls(setMyCommandsSpy, 1);
-    // });
+      assertSpyCalls(setMyCommandsSpy, 1);
+    });
   });
 
   describe("ctx.setMyCommands", () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -96,6 +96,20 @@ describe("Integration", () => {
 
       assertSpyCalls(setMyCommandsSpy, 0);
     });
+    // it("should be hable to set commands with no handler", async () => {
+    //   const myCommands = new CommandGroup({ prefix: "!" });
+    //   myCommands.command("command", "super description");
+
+    //   const setMyCommandsSpy = spy(resolvesNext([true] as const));
+
+    //   await myCommands.setCommands({
+    //     api: {
+    //       raw: { setMyCommands: setMyCommandsSpy },
+    //     } as unknown as Api,
+    //   });
+
+    //   assertSpyCalls(setMyCommandsSpy, 1);
+    // });
   });
 
   describe("ctx.setMyCommands", () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -71,7 +71,11 @@ describe("Integration", () => {
       assertSpyCalls(setMyCommandsSpy, 1);
       assertSpyCall(setMyCommandsSpy, 0, {
         args: [{
-          commands: [{ command: "command", description: "_" }],
+          commands: [{
+            command: "command",
+            description: "_",
+            hasHandler: true,
+          }],
           language_code: undefined,
           scope: {
             type: "default",
@@ -144,7 +148,11 @@ describe("Integration", () => {
       assertSpyCalls(setMyCommandsSpy, 1);
       assertSpyCall(setMyCommandsSpy, 0, {
         args: [{
-          commands: [{ command: "command", description: "_" }],
+          commands: [{
+            command: "command",
+            description: "_",
+            hasHandler: true,
+          }],
           language_code: undefined,
           scope: {
             type: "chat",

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -96,7 +96,7 @@ describe("Integration", () => {
 
       assertSpyCalls(setMyCommandsSpy, 0);
     });
-    it("should be hable to set commands with no handler", async () => {
+    it("should be able to set commands with no handler", async () => {
       const myCommands = new CommandGroup();
       myCommands.command("command", "super description");
 

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -43,7 +43,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
         () => {},
       );
       assertEquals(
-        fuzzyMatch("strt", cmds, { language: "fr" })?.command?.name,
+        fuzzyMatch("strt", cmds, { language: "fr" })?.command?.command,
         "start",
       );
     });
@@ -73,7 +73,7 @@ describe("Jaro-Wrinkler Algorithm", () => {
         (ctx) => ctx.reply(`Hello, ${ctx.chat.first_name}!`),
       );
       assertEquals(
-        fuzzyMatch("magcal", cmds, { language: "fr" })?.command?.name,
+        fuzzyMatch("magcal", cmds, { language: "fr" })?.command?.command,
         "magical_\\d",
       );
     });
@@ -88,11 +88,11 @@ describe("Jaro-Wrinkler Algorithm", () => {
       ).localize("es", /magico_(c|d)/, "Comando Mágico");
 
       assertEquals(
-        fuzzyMatch("magici_c", cmds, { language: "es" })?.command?.name,
+        fuzzyMatch("magici_c", cmds, { language: "es" })?.command?.command,
         "magico_(c|d)",
       );
       assertEquals(
-        fuzzyMatch("magici_a", cmds, { language: "fr" })?.command?.name,
+        fuzzyMatch("magici_a", cmds, { language: "fr" })?.command?.command,
         "magical_(a|b)",
       );
     });
@@ -114,56 +114,56 @@ describe("Jaro-Wrinkler Algorithm", () => {
         const json = cmds.toElementals();
         assertEquals(json, [
           {
-            name: "butcher",
+            command: "butcher",
             language: "default",
             prefix: "?",
             scopes: [{ type: "default" }],
             description: "_",
           },
           {
-            name: "carnicero",
+            command: "carnicero",
             language: "es",
             prefix: "?",
             scopes: [{ type: "default" }],
             description: "a",
           },
           {
-            name: "macellaio",
+            command: "macellaio",
             language: "it",
             prefix: "?",
             scopes: [{ type: "default" }],
             description: "b",
           },
           {
-            name: "duke",
+            command: "duke",
             language: "default",
             prefix: "/",
             scopes: [{ type: "default" }],
             description: "_",
           },
           {
-            name: "duque",
+            command: "duque",
             language: "es",
             prefix: "/",
             scopes: [{ type: "default" }],
             description: "c",
           },
           {
-            name: "duc",
+            command: "duc",
             language: "fr",
             prefix: "/",
             scopes: [{ type: "default" }],
             description: "d",
           },
           {
-            name: "dad_(.*)",
+            command: "dad_(.*)",
             language: "default",
             prefix: "/",
             scopes: [{ type: "default" }],
             description: "dad",
           },
           {
-            name: "papa_(.*)",
+            command: "papa_(.*)",
             language: "es",
             prefix: "/",
             scopes: [{ type: "default" }],
@@ -188,36 +188,36 @@ describe("Jaro-Wrinkler Algorithm", () => {
       it("sv", () => {
         assertEquals(
           fuzzyMatch("hertog", cmds, { language: "sv" })?.command
-            ?.name,
+            ?.command,
           "hertig",
         );
       });
       it("da", () => {
         assertEquals(
           fuzzyMatch("hertog", cmds, { language: "da" })?.command
-            ?.name,
+            ?.command,
           "hertug",
         );
       });
       describe("default", () => {
         it("duke", () =>
           assertEquals(
-            fuzzyMatch("duk", cmds, {})?.command?.name,
+            fuzzyMatch("duk", cmds, {})?.command?.command,
             "duke",
           ));
         it("duke", () =>
           assertEquals(
-            fuzzyMatch("due", cmds, {})?.command?.name,
+            fuzzyMatch("due", cmds, {})?.command?.command,
             "duke",
           ));
         it("duke", () =>
           assertEquals(
-            fuzzyMatch("dule", cmds, {})?.command?.name,
+            fuzzyMatch("dule", cmds, {})?.command?.command,
             "duke",
           ));
         it("duke", () =>
           assertEquals(
-            fuzzyMatch("duje", cmds, {})?.command?.name,
+            fuzzyMatch("duje", cmds, {})?.command?.command,
             "duke",
           ));
       });
@@ -225,19 +225,19 @@ describe("Jaro-Wrinkler Algorithm", () => {
         it("duque", () =>
           assertEquals(
             fuzzyMatch("duquw", cmds, { language: "es" })?.command
-              ?.name,
+              ?.command,
             "duque",
           ));
         it("duque", () =>
           assertEquals(
             fuzzyMatch("duqe", cmds, { language: "es" })?.command
-              ?.name,
+              ?.command,
             "duque",
           ));
         it("duque", () =>
           assertEquals(
             fuzzyMatch("duwue", cmds, { language: "es" })?.command
-              ?.name,
+              ?.command,
             "duque",
           ));
       });
@@ -245,19 +245,19 @@ describe("Jaro-Wrinkler Algorithm", () => {
         it("duc", () =>
           assertEquals(
             fuzzyMatch("duk", cmds, { language: "fr" })?.command
-              ?.name,
+              ?.command,
             "duc",
           ));
         it("duc", () =>
           assertEquals(
             fuzzyMatch("duce", cmds, { language: "fr" })?.command
-              ?.name,
+              ?.command,
             "duc",
           ));
         it("duc", () =>
           assertEquals(
             fuzzyMatch("ducñ", cmds, { language: "fr" })?.command
-              ?.name,
+              ?.command,
             "duc",
           ));
       });
@@ -276,25 +276,25 @@ describe("Jaro-Wrinkler Algorithm", () => {
         it("poussar", () =>
           assertEquals(
             fuzzyMatch("pousssr", cmds, { language: "pt" })?.command
-              ?.name,
+              ?.command,
             "poussar",
           ));
         it("poussar", () =>
           assertEquals(
             fuzzyMatch("pousar", cmds, { language: "pt" })?.command
-              ?.name,
+              ?.command,
             "poussar",
           ));
         it("poussar", () =>
           assertEquals(
             fuzzyMatch("poussqr", cmds, { language: "pt" })?.command
-              ?.name,
+              ?.command,
             "poussar",
           ));
         it("poussar", () =>
           assertEquals(
             fuzzyMatch("poussrr", cmds, { language: "pt" })?.command
-              ?.name,
+              ?.command,
             "poussar",
           ));
       });
@@ -302,25 +302,25 @@ describe("Jaro-Wrinkler Algorithm", () => {
         it("pousser", () =>
           assertEquals(
             fuzzyMatch("pousssr", cmds, { language: "fr" })?.command
-              ?.name,
+              ?.command,
             "pousser",
           ));
         it("pousser", () =>
           assertEquals(
             fuzzyMatch("pouser", cmds, { language: "fr" })?.command
-              ?.name,
+              ?.command,
             "pousser",
           ));
         it("pousser", () =>
           assertEquals(
             fuzzyMatch("pousrr", cmds, { language: "fr" })?.command
-              ?.name,
+              ?.command,
             "pousser",
           ));
         it("pousser", () =>
           assertEquals(
             fuzzyMatch("poussrr", cmds, { language: "fr" })?.command
-              ?.name,
+              ?.command,
             "pousser",
           ));
       });

--- a/test/jaroWrinkler.test.ts
+++ b/test/jaroWrinkler.test.ts
@@ -7,6 +7,7 @@ import { CommandGroup } from "../src/mod.ts";
 import { dummyCtx } from "./context.test.ts";
 import {
   assertEquals,
+  assertObjectMatch,
   assertThrows,
   Context,
   describe,
@@ -110,66 +111,61 @@ describe("Jaro-Wrinkler Algorithm", () => {
 
       cmds.command(/dad_(.*)/, "dad", () => {})
         .localize("es", /papa_(.*)/, "f");
-      it("should output all commands names, language and prefix", () => {
+      it("should output all commands names, language and prefix, and description", () => {
         const json = cmds.toElementals();
-        assertEquals(json, [
+        const expected = [
           {
             command: "butcher",
             language: "default",
             prefix: "?",
-            scopes: [{ type: "default" }],
             description: "_",
           },
           {
             command: "carnicero",
             language: "es",
             prefix: "?",
-            scopes: [{ type: "default" }],
             description: "a",
           },
           {
             command: "macellaio",
             language: "it",
             prefix: "?",
-            scopes: [{ type: "default" }],
             description: "b",
           },
           {
             command: "duke",
             language: "default",
             prefix: "/",
-            scopes: [{ type: "default" }],
             description: "_",
           },
           {
             command: "duque",
             language: "es",
             prefix: "/",
-            scopes: [{ type: "default" }],
             description: "c",
           },
           {
             command: "duc",
             language: "fr",
             prefix: "/",
-            scopes: [{ type: "default" }],
             description: "d",
           },
           {
             command: "dad_(.*)",
             language: "default",
             prefix: "/",
-            scopes: [{ type: "default" }],
             description: "dad",
           },
           {
             command: "papa_(.*)",
             language: "es",
             prefix: "/",
-            scopes: [{ type: "default" }],
             description: "f",
           },
-        ]);
+        ];
+        json.forEach((command, i) => {
+          assertObjectMatch(command, expected[i]);
+        });
       });
     });
     describe("should return the command localization related to the user lang", () => {

--- a/test/utils-test.test.ts
+++ b/test/utils-test.test.ts
@@ -1,15 +1,5 @@
 import { isMiddleware } from "../src/utils/checks.ts";
-import { CommandsFlavor } from "../src/context.ts";
-import { CommandGroup, commandNotFound } from "../src/mod.ts";
-import { dummyCtx } from "./context.test.ts";
-import {
-  assert,
-  assertEquals,
-  assertFalse,
-  Context,
-  describe,
-  it,
-} from "./deps.test.ts";
+import { assert, describe, it } from "./deps.test.ts";
 import { Composer } from "../src/deps.deno.ts";
 
 describe("Utils tests", () => {


### PR DESCRIPTION
As discussed in the [telegram group](https://t.me/grammyjs/286108)

allows for stuff like:
```ts
const commands = new CommandGroup();
commands.command("start", i18n.t(DEFAULT_LOCALE, "commands.start.description"))
    .localize("de", "start", i18n.t("de", "commands.start.description"));

await commands.setCommands(bot);
```
changes:
- Add next-only handler at command creation if no handler is pass
- Mark commands with no handler for inspecting them with toElementals or toArgs or toSingleScopeArgs
- Change type CommandElementals name to BotCommandX and inherit it from BotCommand Instead