### PR TITLE
Allow anonymous admins to use admin scoped commands

### DIFF
--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -1,8 +1,17 @@
-import { Composer, Context, Middleware } from "../deps.deno.ts";
+import {
+  ChatTypeContext,
+  Composer,
+  Context,
+  Middleware,
+} from "../deps.deno.ts";
 import { CommandOptions } from "../types.ts";
 import { MaybeArray } from "./array.ts";
 
-export function isAdmin(ctx: Context) {
+export function isAdmin(ctx: ChatTypeContext<Context, "group" | "supergroup">) {
+  if (ctx.senderChat?.id === ctx.chat.id) {
+    // anonymous admin
+    return true;
+  }
   return ctx
     .getAuthor()
     .then((author) => ["administrator", "creator"].includes(author.status));

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -932,6 +932,19 @@ describe("Command", () => {
       assertSpyCalls(chatAdministratorsSpy, 1);
     });
 
+    it("should call chatAdministrators for anonymous admin", async () => {
+      chatMember = { status: "member" } as ChatMember; // unused
+
+      assertSpyCalls(chatAdministratorsSpy, 1);
+      await mw(makeContext({
+        chat: { id: -123, type: "group" },
+        from: { id: 789 },
+        sender_chat: { id: -123, type: "group" },
+        text: "/a",
+      } as Message));
+      assertSpyCalls(chatAdministratorsSpy, 2);
+    });
+
     it("should call chat", async () => {
       assertSpyCalls(chatSpy, 0);
       await mw(makeContext({
@@ -964,6 +977,19 @@ describe("Command", () => {
       assertSpyCalls(allChatAdministratorsSpy, 1);
     });
 
+    it("should call allChatAdministrators for anonymous admin", async () => {
+      chatMember = { status: "administrator" } as ChatMember; // unused
+
+      assertSpyCalls(allChatAdministratorsSpy, 1);
+      await mw(makeContext({
+        chat: { id: -124, type: "group" },
+        from: { id: 789 },
+        sender_chat: { id: -124, type: "group" },
+        text: "/a",
+      } as Message));
+      assertSpyCalls(allChatAdministratorsSpy, 2);
+    });
+
     it("should call allGroupChats", async () => {
       chatMember = { status: "member" } as ChatMember;
 
@@ -994,6 +1020,19 @@ describe("Command", () => {
         text: "/a",
       } as Message));
       assertSpyCalls(defaultSpy, 1);
+    });
+
+    it("should call group on sender_chat", async () => {
+      chatMember = { status: "member" } as ChatMember;
+
+      assertSpyCalls(allGroupChatsSpy, 1);
+      await mw(makeContext({
+        chat: { id: -124, type: "group" },
+        from: { id: 789 },
+        sender_chat: { id: -123, type: "channel" },
+        text: "/a",
+      } as Message));
+      assertSpyCalls(allGroupChatsSpy, 2);
     });
   });
 });


### PR DESCRIPTION
Currently anonymous admins are unable to use admin scoped commands, despite them being displayed in the user interface. The docs say about sender_chat:

> Optional. Sender of the message when sent on behalf of a chat. For example, the supergroup itself for messages sent by its anonymous administrators or a linked channel for messages automatically forwarded to the channel's discussion group. [...]

There should be no other way to send a message on behalf of a group.

This pull request updates the `isAdmin` function to take into account anonymous admins.