### PR TITLE
feat: support ephemeral bot commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,36 @@ bot.on("message", async (ctx) => {
 
 bot.start();
 ```
+
+### Ephemeral commands
+
+Commands can be marked as [ephemeral](https://core.telegram.org/bots/features#ephemeral-messages).
+When a user sends an ephemeral command in a group, their message stays invisible to other group members, and Telegram
+clients highlight the command with a special icon in the bot menu.
+
+```ts
+import { Bot } from "grammy";
+import { CommandGroup } from "@grammyjs/commands";
+
+const bot = new Bot("<telegram token>");
+
+const myCommands = new CommandGroup();
+
+myCommands
+  .command("whisper", "Replies with a message only you can see")
+  .ephemeral()
+  .addToScope(
+    { type: "all_group_chats" },
+    (ctx) =>
+      ctx.reply("This is only visible to you", {
+        receiver_user_id: ctx.from.id,
+      }),
+  );
+
+// Calls `setMyCommands` with `is_ephemeral: true` for the command
+await myCommands.setCommands(bot);
+
+bot.use(myCommands);
+
+bot.start();
+```

--- a/README.md
+++ b/README.md
@@ -74,36 +74,3 @@ bot.on("message", async (ctx) => {
 
 bot.start();
 ```
-
-### Ephemeral commands
-
-Commands can be marked as [ephemeral](https://core.telegram.org/bots/features#ephemeral-messages).
-When a user sends an ephemeral command in a group, their message stays invisible to other group members, and Telegram
-clients highlight the command with a special icon in the bot menu.
-
-```ts
-import { Bot } from "grammy";
-import { CommandGroup } from "@grammyjs/commands";
-
-const bot = new Bot("<telegram token>");
-
-const myCommands = new CommandGroup();
-
-myCommands
-  .command("whisper", "Replies with a message only you can see")
-  .ephemeral()
-  .addToScope(
-    { type: "all_group_chats" },
-    (ctx) =>
-      ctx.reply("This is only visible to you", {
-        receiver_user_id: ctx.from.id,
-      }),
-  );
-
-// Calls `setMyCommands` with `is_ephemeral: true` for the command
-await myCommands.setCommands(bot);
-
-bot.use(myCommands);
-
-bot.start();
-```

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,13 @@
         "typescript": "^5.6.3"
       },
       "peerDependencies": {
-        "grammy": "^1.17.1"
+        "grammy": "^1.45.1"
       }
     },
     "node_modules/@grammyjs/types": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.15.0.tgz",
-      "integrity": "sha512-XQHJNlF6AuJgVPYL8mEWrYk4Pg/FoP9PryTVSObtf/SWRIk0dCBkIwSaGGoXa1VDrLVWl/dIP79FgS2acJJjdg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-4.0.0.tgz",
+      "integrity": "sha512-Z8lDLTvOlo12e5Vnly/vQh3JC9ppaitS1dGZ3w068gNitOd/y8tTSiib+Xm38aBGbtYGmUZwOc6afYrLs2CSTg==",
       "license": "MIT",
       "peer": true
     },
@@ -69,9 +69,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -126,15 +126,15 @@
       }
     },
     "node_modules/grammy": {
-      "version": "1.31.3",
-      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.31.3.tgz",
-      "integrity": "sha512-o1OlFzbTt4mvQVCTpcpdedAYrS5DOeal9IBf3FJ7l0A6FbLE9zuPuXa4XFiPvYCmRMVR7f+qcoTZyOpeYg9Xvw==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.45.1.tgz",
+      "integrity": "sha512-Y4VL/hqJMZZxwlUr5ZgM68CFu2iIeEkNLR1cY3+Ww68CIvWARDsoXFix7+31rmyC0+7L85ZI+Pq3E5JSG5+nLQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@grammyjs/types": "3.15.0",
+        "@grammyjs/types": "4.0.0",
         "abort-controller": "^3.0.0",
-        "debug": "^4.3.4",
+        "debug": "^4.4.3",
         "node-fetch": "^2.7.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/grammyjs/commands/issues"
   },
   "peerDependencies": {
-    "grammy": "^1.17.1"
+    "grammy": "^1.45.1"
   },
   "devDependencies": {
     "deno2node": "^1.14.0",

--- a/src/command-group.ts
+++ b/src/command-group.ts
@@ -320,6 +320,7 @@ export class CommandGroup<C extends Context> {
               ...(command.hasHandler
                 ? { hasHandler: true }
                 : { hasHandler: false }),
+              ...(command.isEphemeral ? { is_ephemeral: true } : {}),
             });
           }
           if (filterLanguage) {

--- a/src/command-group.ts
+++ b/src/command-group.ts
@@ -320,7 +320,9 @@ export class CommandGroup<C extends Context> {
               ...(command.hasHandler
                 ? { hasHandler: true }
                 : { hasHandler: false }),
-              ...(command.isEphemeral ? { is_ephemeral: true } : {}),
+              ...(command.isEphemeral
+                ? { is_ephemeral: true }
+                : { is_ephemeral: false }),
             });
           }
           if (filterLanguage) {

--- a/src/command.ts
+++ b/src/command.ts
@@ -619,7 +619,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
       this.registerScopeHandlers();
     }
 
-    const middleware = this._cachedComposer.middleware();
+    const mw = this._cachedComposer.middleware();
     return (ctx: C, next: NextFunction) => {
       if (
         this._isEphemeral && this._ephemeralStrict &&
@@ -627,7 +627,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
       ) {
         return next();
       }
-      return middleware(ctx, next);
+      return mw(ctx, next);
     };
   }
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -65,6 +65,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
   > = new Map();
   private _defaultScopeComposer = new Composer<C>();
   private _isEphemeral: boolean = false;
+  private _ephemeralStrict: boolean = true;
   private _options: CommandOptions = {
     prefix: "/",
     matchOnlyAtStart: true,
@@ -284,9 +285,16 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
   }
 
   /**
-   * Marks this command as ephemeral (or not).
+   * Marks this command as ephemeral.
    * This adds `is_ephemeral: true` to the command when it is serialized
    * for a `setMyCommands` call.
+   *
+   * By default, the handlers of an ephemeral command only run when the
+   * incoming command message was itself sent ephemerally, that is, when the
+   * user invoked the command from the bot's command menu. Pass
+   * `{ strict: false }` to also run the handlers when the command is sent
+   * as a regular, non-ephemeral message, for example when the user types
+   * the command out manually.
    *
    * @example
    * ```ts
@@ -295,10 +303,13 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
    *  .ephemeral()
    * ```
    *
-   * @param isEphemeral Whether the command should be ephemeral. Defaults to `true`.
+   * @param options Options for the ephemeral command
+   * @param options.strict Whether to only handle invocations of this command
+   * that were sent ephemerally. Defaults to `true`.
    */
-  public ephemeral(isEphemeral = true): this {
-    this._isEphemeral = isEphemeral;
+  public ephemeral(options: { strict?: boolean } = {}): this {
+    this._isEphemeral = true;
+    this._ephemeralStrict = options.strict ?? true;
     return this;
   }
 
@@ -607,6 +618,15 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
       this.registerScopeHandlers();
     }
 
-    return this._cachedComposer.middleware();
+    const middleware = this._cachedComposer.middleware();
+    return (ctx: C, next: NextFunction) => {
+      if (
+        this._isEphemeral && this._ephemeralStrict &&
+        ctx.msg?.ephemeral_message_id === undefined
+      ) {
+        return next();
+      }
+      return middleware(ctx, next);
+    };
   }
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -290,11 +290,12 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
    * for a `setMyCommands` call.
    *
    * By default, the handlers of an ephemeral command only run when the
-   * incoming command message was itself sent ephemerally, that is, when the
-   * user invoked the command from the bot's command menu. Pass
-   * `{ strict: false }` to also run the handlers when the command is sent
-   * as a regular, non-ephemeral message, for example when the user types
-   * the command out manually.
+   * incoming command message was itself sent ephemerally. Pass
+   * `{ strict: false }` to also run the handlers when the command is
+   * sent as a regular, non-ephemeral message.
+   *
+   * Note: Some clients may send a command regularly if it is typed out
+   * rather than selected from the command menu.
    *
    * @example
    * ```ts

--- a/src/command.ts
+++ b/src/command.ts
@@ -529,7 +529,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
         : localizedName,
       description: this.getLocalizedDescription(languageCode),
       ...(this.hasHandler ? { hasHandler: true } : { hasHandler: false }),
-      ...(this.isEphemeral ? { is_ephemeral: true } : {}),
+      ...(this.isEphemeral ? { is_ephemeral: true } : { is_ephemeral: false }),
     };
   }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -64,6 +64,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
     { name: string | RegExp; description: string }
   > = new Map();
   private _defaultScopeComposer = new Composer<C>();
+  private _isEphemeral: boolean = false;
   private _options: CommandOptions = {
     prefix: "/",
     matchOnlyAtStart: true,
@@ -268,6 +269,37 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
    */
   get hasHandler(): boolean {
     return this._hasHandler;
+  }
+
+  /**
+   * Whether this command is ephemeral.
+   *
+   * Ephemeral commands are highlighted with a special icon in the bot menu,
+   * and the user's command message stays invisible to other group members.
+   *
+   * @see https://core.telegram.org/bots/features#ephemeral-messages
+   */
+  get isEphemeral(): boolean {
+    return this._isEphemeral;
+  }
+
+  /**
+   * Marks this command as ephemeral (or not).
+   * This adds `is_ephemeral: true` to the command when it is serialized
+   * for a `setMyCommands` call.
+   *
+   * @example
+   * ```ts
+   * myCommands
+   *  .command("whisper", "Sends a private reply inside a group")
+   *  .ephemeral()
+   * ```
+   *
+   * @param isEphemeral Whether the command should be ephemeral. Defaults to `true`.
+   */
+  public ephemeral(isEphemeral = true): this {
+    this._isEphemeral = isEphemeral;
+    return this;
   }
 
   /**
@@ -486,7 +518,10 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
    */
   public toObject(
     languageCode: LanguageCode | "default" = "default",
-  ): Pick<BotCommandX, "command" | "description" | "hasHandler"> {
+  ): Pick<
+    BotCommandX,
+    "command" | "description" | "hasHandler" | "is_ephemeral"
+  > {
     const localizedName = this.getLocalizedName(languageCode);
     return {
       command: localizedName instanceof RegExp
@@ -494,6 +529,7 @@ export class Command<C extends Context = Context> implements MiddlewareObj<C> {
         : localizedName,
       description: this.getLocalizedDescription(languageCode),
       ...(this.hasHandler ? { hasHandler: true } : { hasHandler: false }),
+      ...(this.isEphemeral ? { is_ephemeral: true } : {}),
     };
   }
 

--- a/test/command-group.test.ts
+++ b/test/command-group.test.ts
@@ -154,11 +154,17 @@ describe("CommandGroup", () => {
             scope: { type: "chat", chat_id: 10 },
             language_code: undefined,
             commands: [
-              { command: "test", description: "handler", hasHandler: true },
+              {
+                command: "test",
+                description: "handler",
+                hasHandler: true,
+                is_ephemeral: false,
+              },
               {
                 command: "markme",
                 description: "nohandler",
                 hasHandler: false,
+                is_ephemeral: false,
               },
             ],
           },
@@ -185,6 +191,7 @@ describe("CommandGroup", () => {
                   command: "withoutcustomprefix",
                   description: "handler",
                   hasHandler: true,
+                  is_ephemeral: false,
                 },
               ],
             },

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -1068,7 +1068,7 @@ describe("Command", () => {
       const command = new Command("whisper", "whispers", () => {});
 
       assertFalse(command.isEphemeral);
-      assertFalse("is_ephemeral" in command.toObject());
+      assertEquals(command.toObject().is_ephemeral, false);
     });
 
     it("should mark a command as ephemeral", () => {
@@ -1090,7 +1090,7 @@ describe("Command", () => {
         .ephemeral(false);
 
       assertFalse(command.isEphemeral);
-      assertFalse("is_ephemeral" in command.toObject());
+      assertEquals(command.toObject().is_ephemeral, false);
     });
 
     it("should serialize is_ephemeral through toArgs", () => {

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -1,4 +1,5 @@
 import { Command } from "../src/command.ts";
+import { CommandGroup } from "../src/mod.ts";
 import { CommandOptions } from "../src/types.ts";
 import { isCommandOptions, matchesPattern } from "../src/utils/checks.ts";
 import {
@@ -1059,6 +1060,57 @@ describe("Command", () => {
         text: "/a",
       } as Message));
       assertSpyCalls(allGroupChatsSpy, 2);
+    });
+  });
+
+  describe("ephemeral", () => {
+    it("should not mark commands as ephemeral by default", () => {
+      const command = new Command("whisper", "whispers", () => {});
+
+      assertFalse(command.isEphemeral);
+      assertFalse("is_ephemeral" in command.toObject());
+    });
+
+    it("should mark a command as ephemeral", () => {
+      const command = new Command("whisper", "whispers", () => {})
+        .ephemeral();
+
+      assert(command.isEphemeral);
+      assertEquals(command.toObject(), {
+        command: "whisper",
+        description: "whispers",
+        hasHandler: true,
+        is_ephemeral: true,
+      });
+    });
+
+    it("should allow unmarking a command as ephemeral", () => {
+      const command = new Command("whisper", "whispers", () => {})
+        .ephemeral()
+        .ephemeral(false);
+
+      assertFalse(command.isEphemeral);
+      assertFalse("is_ephemeral" in command.toObject());
+    });
+
+    it("should serialize is_ephemeral through toArgs", () => {
+      const myCommands = new CommandGroup();
+      myCommands.command("whisper", "whispers", () => {}).ephemeral();
+
+      const { scopes } = myCommands.toArgs();
+      const commands = scopes.flatMap(({ commands }) => commands);
+
+      assertEquals(commands.length, 1);
+      assertEquals(commands[0].is_ephemeral, true);
+    });
+
+    it("should serialize is_ephemeral through toElementals", () => {
+      const myCommands = new CommandGroup();
+      myCommands.command("whisper", "whispers", () => {}).ephemeral();
+
+      const elementals = myCommands.toElementals();
+
+      assertEquals(elementals[0].is_ephemeral, true);
     });
   });
 });

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -1064,6 +1064,9 @@ describe("Command", () => {
   });
 
   describe("ephemeral", () => {
+    const makeContext = (message: Message) =>
+      new Context({ message, update_id: 1 } as Update, api, me);
+
     it("should not mark commands as ephemeral by default", () => {
       const command = new Command("whisper", "whispers", () => {});
 
@@ -1084,13 +1087,34 @@ describe("Command", () => {
       });
     });
 
-    it("should allow unmarking a command as ephemeral", () => {
-      const command = new Command("whisper", "whispers", () => {})
-        .ephemeral()
-        .ephemeral(false);
+    it("should ignore non-ephemeral invocations by default", async () => {
+      const handlerSpy = spy();
+      const command = new Command("whisper", "whispers", handlerSpy)
+        .ephemeral();
+      const mw = (ctx: Context) =>
+        command.middleware()(ctx, () => Promise.resolve());
 
-      assertFalse(command.isEphemeral);
-      assertEquals(command.toObject().is_ephemeral, false);
+      await mw(makeContext({ ...m, text: "/whisper" } as Message));
+      assertSpyCalls(handlerSpy, 0);
+
+      await mw(makeContext({
+        ...m,
+        text: "/whisper",
+        message_id: 0,
+        ephemeral_message_id: 1,
+      } as Message));
+      assertSpyCalls(handlerSpy, 1);
+    });
+
+    it("should handle non-ephemeral invocations with strict: false", async () => {
+      const handlerSpy = spy();
+      const command = new Command("whisper", "whispers", handlerSpy)
+        .ephemeral({ strict: false });
+      const mw = (ctx: Context) =>
+        command.middleware()(ctx, () => Promise.resolve());
+
+      await mw(makeContext({ ...m, text: "/whisper" } as Message));
+      assertSpyCalls(handlerSpy, 1);
     });
 
     it("should serialize is_ephemeral through toArgs", () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -79,6 +79,7 @@ describe("Integration", () => {
             command: "command",
             description: "_",
             hasHandler: true,
+            is_ephemeral: false,
           }],
           language_code: undefined,
           scope: {
@@ -156,6 +157,7 @@ describe("Integration", () => {
             command: "command",
             description: "_",
             hasHandler: true,
+            is_ephemeral: false,
           }],
           language_code: undefined,
           scope: {


### PR DESCRIPTION
Add an ephemeral command modifier and serialize is_ephemeral through command registration and elemental representations. Document usage and update grammY for Bot API type support.

Addresses #81.

AI use disclosure:
- Implementation by Kimi K3.
- Review by GPT 5.6 Sol.