### PR TITLE
chore: replace lib.deno.dev imports with libdenodev.knightniwrem.deno…

### DIFF
--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -10,7 +10,7 @@ export {
   type Middleware,
   type MiddlewareObj,
   type NextFunction,
-} from "https://lib.deno.dev/x/grammy@1/mod.ts";
+} from "https://libdenodev.knightniwrem.deno.net/x/grammy@1/mod.ts";
 export type {
   BotCommand,
   BotCommandScope,
@@ -21,6 +21,6 @@ export type {
   Chat,
   LanguageCode,
   MessageEntity,
-} from "https://lib.deno.dev/x/grammy@1/types.ts";
+} from "https://libdenodev.knightniwrem.deno.net/x/grammy@1/types.ts";
 // TODO: bring this back once the types are available on the "web" runtimes
-// export { LanguageCodes } from "https://lib.deno.dev/x/grammy@1/types.ts";
+// export { LanguageCodes } from "https://libdenodev.knightniwrem.deno.net/x/grammy@1/types.ts";

--- a/test/deps.test.ts
+++ b/test/deps.test.ts
@@ -24,7 +24,10 @@ export {
   type Stub,
   stub,
 } from "https://deno.land/std@0.203.0/testing/mock.ts";
-export { Api, Context } from "https://lib.deno.dev/x/grammy@1/mod.ts";
+export {
+  Api,
+  Context,
+} from "https://libdenodev.knightniwrem.deno.net/x/grammy@1/mod.ts";
 export type {
   Chat,
   ChatMember,
@@ -32,4 +35,4 @@ export type {
   Update,
   User,
   UserFromGetMe,
-} from "https://lib.deno.dev/x/grammy@1/types.ts";
+} from "https://libdenodev.knightniwrem.deno.net/x/grammy@1/types.ts";

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -33,6 +33,8 @@ const getBot = () =>
       has_main_web_app: false,
       has_topics_enabled: false,
       allows_users_to_create_topics: false,
+      can_manage_bots: false,
+      supports_join_request_queries: false,
     },
   });
 


### PR DESCRIPTION
….net

Temporary workaround: lib.deno.dev is down because Classic Deno Deploy has been shut down. Revert this once lib.deno.dev is restored.

Source for the workaround mirror:
https://github.com/KnightNiwrem/lib.deno.dev/tree/main